### PR TITLE
creates the browser builder based on what is configured rather than on…

### DIFF
--- a/builders/cordova-build/index.ts
+++ b/builders/cordova-build/index.ts
@@ -1,6 +1,4 @@
 import { BuildEvent, Builder, BuilderConfiguration, BuilderContext } from '@angular-devkit/architect';
-import { BrowserBuilder } from '@angular-devkit/build-angular/src/browser';
-import { BrowserBuilderSchema } from '@angular-devkit/build-angular/src/browser/schema';
 import { getSystemPath, join, normalize } from '@angular-devkit/core';
 import { Observable, of } from 'rxjs';
 import { concatMap, tap } from 'rxjs/operators';
@@ -8,20 +6,33 @@ import { concatMap, tap } from 'rxjs/operators';
 import { CordovaBuildBuilderSchema } from './schema';
 
 export { CordovaBuildBuilderSchema };
+import * as fs from 'fs';
+import * as path from 'path';
 
 export class CordovaBuildBuilder implements Builder<CordovaBuildBuilderSchema> {
-  constructor(public context: BuilderContext) {}
+  private configuredBuilder: string;
+  private configuredBuilderPath: string;
+  private originalArchitectureConfig: any;
+  private BrowserBuilder: any;
+  constructor(public context: BuilderContext) {
+    const architectConfigFile = fs.readFileSync(this.context.workspace.root + '/angular.json');
+    this.originalArchitectureConfig = JSON.parse(architectConfigFile.toString());
+    this.configuredBuilder = this.originalArchitectureConfig.projects.app.architect.build.builder.replace(':browser', '');
+    this.configuredBuilderPath = path.resolve('node_modules', this.configuredBuilder + '/src/browser');
+
+    this.BrowserBuilder = require(this.configuredBuilderPath).default;
+  }
 
   run(builderConfig: BuilderConfiguration<CordovaBuildBuilderSchema>): Observable<BuildEvent> {
-    const browserBuilder = new BrowserBuilder(this.context); // TODO: shouldn't this use `architect.getBuilder()`?
+    const browserBuilder = new this.BrowserBuilder(this.context);
 
     return this.buildBrowserConfig(builderConfig.options).pipe(
       concatMap(browserConfig => browserBuilder.run(browserConfig))
     );
   }
 
-  buildBrowserConfig(options: CordovaBuildBuilderSchema): Observable<BuilderConfiguration<BrowserBuilderSchema>> {
-    let browserConfig: BuilderConfiguration<BrowserBuilderSchema>;
+  buildBrowserConfig(options: CordovaBuildBuilderSchema): Observable<BuilderConfiguration<any>> {
+    let browserConfig: BuilderConfiguration<any>;
 
     return of(null).pipe(// tslint:disable-line:no-null-keyword
       concatMap(() => this._getBrowserConfig(options)),
@@ -32,7 +43,7 @@ export class CordovaBuildBuilder implements Builder<CordovaBuildBuilderSchema> {
   }
 
   // Mutates browserOptions
-  prepareBrowserConfig(options: CordovaBuildBuilderSchema, browserOptions: BrowserBuilderSchema) {
+  prepareBrowserConfig(options: CordovaBuildBuilderSchema, browserOptions: any) {
     const cordovaBasePath = normalize(options.cordovaBasePath ? options.cordovaBasePath : '.');
 
     // We always need to output the build to `www` because it is a hard
@@ -61,11 +72,11 @@ export class CordovaBuildBuilder implements Builder<CordovaBuildBuilderSchema> {
     }
   }
 
-  protected _getBrowserConfig(options: CordovaBuildBuilderSchema): Observable<BuilderConfiguration<BrowserBuilderSchema>> {
+  protected _getBrowserConfig(options: CordovaBuildBuilderSchema): Observable<BuilderConfiguration<any>> {
     const { architect } = this.context;
     const [ project, target, configuration ] = options.browserTarget.split(':');
     const browserTargetSpec = { project, target, configuration, overrides: {} };
-    const builderConfig = architect.getBuilderConfiguration<BrowserBuilderSchema>(browserTargetSpec);
+    const builderConfig = architect.getBuilderConfiguration<any>(browserTargetSpec);
 
     return architect.getBuilderDescription(builderConfig).pipe(
       concatMap(browserDescription => architect.validateBuilderOptions(builderConfig, browserDescription))

--- a/package.json
+++ b/package.json
@@ -56,10 +56,10 @@
     "tslint-ionic-rules": "0.0.19"
   },
   "peerDependencies": {
-    "@angular-devkit/architect": "0.9.0-beta.3",
-    "@angular-devkit/build-angular": "0.9.0-beta.3",
-    "@angular-devkit/core": "0.9.0-beta.3",
-    "@angular-devkit/schematics": "0.9.0-beta.3"
+    "@angular-devkit/architect": ">=0.7.2 <7.0.0",
+    "@angular-devkit/build-angular": ">=0.7.2 <7.0.0",
+    "@angular-devkit/core": ">=0.7.2 <7.0.0",
+    "@angular-devkit/schematics": ">=0.7.2 <7.0.0"
   },
   "builders": "./builders.json",
   "schematics": "./collection.json",


### PR DESCRIPTION
… the angular-devkit/build-angular:browser

I'm using a custom builder for webpack with my build. I need to the same build with the cordova commands. 

I'm not sure if this the correct approach: please provide direction if it is not.

