### PR TITLE
Add cordovaBasePath to overrides options

### DIFF
--- a/builders/cordova-serve/index.ts
+++ b/builders/cordova-serve/index.ts
@@ -33,9 +33,9 @@ export class CordovaServeBuilder implements Builder<CordovaServeBuilderSchema> {
   }
 
   protected _getCordovaBuildConfig(cordovaServeOptions: CordovaServeBuilderSchema): Observable<BuilderConfiguration<CordovaBuildBuilderSchema>> {
-    const { platform } = cordovaServeOptions;
-    const [ project, target, configuration ] = cordovaServeOptions.cordovaBuildTarget.split(':');
-    const cordovaBuildTargetSpec = { project, target, configuration, overrides: { platform } };
+    const {platform,cordovaBasePath} = cordovaServeOptions;
+    const [project, target, configuration] = cordovaServeOptions.cordovaBuildTarget.split(':');
+    const cordovaBuildTargetSpec = {project,target,configuration,overrides: {platform,cordovaBasePath}};
     const cordovaBuildTargetConfig = this.context.architect.getBuilderConfiguration<CordovaBuildBuilderSchema>(cordovaBuildTargetSpec);
 
     return this.context.architect.getBuilderDescription(cordovaBuildTargetConfig).pipe(

--- a/builders/cordova-serve/index.ts
+++ b/builders/cordova-serve/index.ts
@@ -35,7 +35,7 @@ export class CordovaServeBuilder implements Builder<CordovaServeBuilderSchema> {
     );
   }
 
-https://github.com/ionic-team/angular-toolkit/pull/57  protected _getCordovaBuildConfig(cordovaServeOptions: CordovaServeBuilderSchema): Observable<BuilderConfiguration<CordovaBuildBuilderSchema>> {
+  protected _getCordovaBuildConfig(cordovaServeOptions: CordovaServeBuilderSchema): Observable<BuilderConfiguration<CordovaBuildBuilderSchema>> {
     const { platform, cordovaBasePath, cordovaAssets, cordovaMock } = cordovaServeOptions;
     const [ project, target, configuration ] = cordovaServeOptions.cordovaBuildTarget.split(':');
     const cordovaBuildTargetSpec = { project, target, configuration, overrides: { platform, cordovaBasePath, cordovaAssets, cordovaMock } };

--- a/builders/cordova-serve/index.ts
+++ b/builders/cordova-serve/index.ts
@@ -38,7 +38,7 @@ export class CordovaServeBuilder implements Builder<CordovaServeBuilderSchema> {
   protected _getCordovaBuildConfig(cordovaServeOptions: CordovaServeBuilderSchema): Observable<BuilderConfiguration<CordovaBuildBuilderSchema>> {
     const {platform,cordovaBasePath} = cordovaServeOptions;
     const [project, target, configuration] = cordovaServeOptions.cordovaBuildTarget.split(':');
-    const cordovaBuildTargetSpec = {project,target,configuration,overrides: {platform,cordovaBasePath}};
+    const cordovaBuildTargetSpec = {project, target, configuration, overrides: { platform, cordovaBasePath }};
     const cordovaBuildTargetConfig = this.context.architect.getBuilderConfiguration<CordovaBuildBuilderSchema>(cordovaBuildTargetSpec);
 
     return this.context.architect.getBuilderDescription(cordovaBuildTargetConfig).pipe(

--- a/builders/cordova-serve/index.ts
+++ b/builders/cordova-serve/index.ts
@@ -36,9 +36,9 @@ export class CordovaServeBuilder implements Builder<CordovaServeBuilderSchema> {
   }
 
   protected _getCordovaBuildConfig(cordovaServeOptions: CordovaServeBuilderSchema): Observable<BuilderConfiguration<CordovaBuildBuilderSchema>> {
-    const {platform,cordovaBasePath} = cordovaServeOptions;
+    const { platform, cordovaBasePath } = cordovaServeOptions;
     const [project, target, configuration] = cordovaServeOptions.cordovaBuildTarget.split(':');
-    const cordovaBuildTargetSpec = {project, target, configuration, overrides: { platform, cordovaBasePath }};
+    const cordovaBuildTargetSpec = { project, target, configuration, overrides: { platform, cordovaBasePath } };
     const cordovaBuildTargetConfig = this.context.architect.getBuilderConfiguration<CordovaBuildBuilderSchema>(cordovaBuildTargetSpec);
 
     return this.context.architect.getBuilderDescription(cordovaBuildTargetConfig).pipe(


### PR DESCRIPTION
The cordovaBasePath property is required for Monorepo projects, since the applications are not in the project root.