### PR TITLE
feat(build): add `--cordova-mock` option

### DIFF
--- a/builders/cordova-build/cordova.js
+++ b/builders/cordova-build/cordova.js
@@ -1,0 +1,1 @@
+// mock cordova.js

--- a/builders/cordova-build/schema.d.ts
+++ b/builders/cordova-build/schema.d.ts
@@ -1,7 +1,8 @@
 export interface CordovaBuildBuilderSchema {
   browserTarget: string;
-  platform: string;
+  platform?: string;
   cordovaBasePath?: string;
   sourceMap?: boolean;
   cordovaAssets?: boolean;
+  cordovaMock?: boolean;
 }

--- a/builders/cordova-build/schema.json
+++ b/builders/cordova-build/schema.json
@@ -23,11 +23,15 @@
       "type": "boolean",
       "description": "Bundle Cordova assets with build",
       "default": true
+    },
+    "cordovaMock": {
+      "type": "boolean",
+      "description": "Bundle empty cordova.js with build",
+      "default": false
     }
   },
   "additionalProperties": false,
   "required": [
-    "browserTarget",
-    "platform"
+    "browserTarget"
   ]
 }

--- a/builders/cordova-serve/index.ts
+++ b/builders/cordova-serve/index.ts
@@ -1,5 +1,5 @@
 import { BuildEvent, Builder, BuilderConfiguration, BuilderContext, BuilderDescription } from '@angular-devkit/architect';
-import { BrowserBuilderSchema } from '@angular-devkit/build-angular/src/browser/schema';
+import { NormalizedBrowserBuilderSchema } from '@angular-devkit/build-angular/src/browser/schema';
 import { DevServerBuilder, DevServerBuilderOptions } from '@angular-devkit/build-angular/src/dev-server';
 import { Path, virtualFs } from '@angular-devkit/core';
 import * as fs from 'fs';
@@ -52,7 +52,7 @@ class CordovaDevServerBuilder extends DevServerBuilder {
     super(context);
   }
 
-  buildWebpackConfig(root: Path, projectRoot: Path, host: virtualFs.Host<fs.Stats>, browserOptions: BrowserBuilderSchema) {
+  buildWebpackConfig(root: Path, projectRoot: Path, host: virtualFs.Host<fs.Stats>, browserOptions: NormalizedBrowserBuilderSchema) {
     const builder = new CordovaBuildBuilder(this.context);
     builder.prepareBrowserConfig(this.cordovaBuildOptions, browserOptions);
 

--- a/builders/cordova-serve/index.ts
+++ b/builders/cordova-serve/index.ts
@@ -36,9 +36,9 @@ export class CordovaServeBuilder implements Builder<CordovaServeBuilderSchema> {
   }
 
   protected _getCordovaBuildConfig(cordovaServeOptions: CordovaServeBuilderSchema): Observable<BuilderConfiguration<CordovaBuildBuilderSchema>> {
-    const { platform } = cordovaServeOptions;
+    const { platform, cordovaAssets, cordovaMock } = cordovaServeOptions;
     const [ project, target, configuration ] = cordovaServeOptions.cordovaBuildTarget.split(':');
-    const cordovaBuildTargetSpec = { project, target, configuration, overrides: { platform } };
+    const cordovaBuildTargetSpec = { project, target, configuration, overrides: { platform, cordovaAssets, cordovaMock } };
     const cordovaBuildTargetConfig = this.context.architect.getBuilderConfiguration<CordovaBuildBuilderSchema>(cordovaBuildTargetSpec);
 
     return this.context.architect.getBuilderDescription(cordovaBuildTargetConfig).pipe(
@@ -54,6 +54,7 @@ class CordovaDevServerBuilder extends DevServerBuilder {
 
   buildWebpackConfig(root: Path, projectRoot: Path, host: virtualFs.Host<fs.Stats>, browserOptions: NormalizedBrowserBuilderSchema) {
     const builder = new CordovaBuildBuilder(this.context);
+    builder.validateBuilderConfig(this.cordovaBuildOptions);
     builder.prepareBrowserConfig(this.cordovaBuildOptions, browserOptions);
 
     return super.buildWebpackConfig(root, projectRoot, host, browserOptions);

--- a/builders/cordova-serve/schema.d.ts
+++ b/builders/cordova-serve/schema.d.ts
@@ -1,10 +1,12 @@
 export interface CordovaServeBuilderSchema {
   cordovaBuildTarget: string;
   devServerTarget: string;
-  platform: string;
+  platform?: string;
   port?: number;
   host?: string;
   ssl?: boolean;
   cordovaBasePath?: string;
   sourceMap?: boolean;
+  cordovaAssets?: boolean;
+  cordovaMock?: boolean;
 }

--- a/builders/cordova-serve/schema.json
+++ b/builders/cordova-serve/schema.json
@@ -37,12 +37,21 @@
     "sourceMap":  {
       "type": "boolean",
       "description": "Create source-map file"
+    },
+    "cordovaAssets": {
+      "type": "boolean",
+      "description": "Bundle Cordova assets with build",
+      "default": true
+    },
+    "cordovaMock": {
+      "type": "boolean",
+      "description": "Bundle empty cordova.js with build",
+      "default": false
     }
   },
   "additionalProperties": false,
   "required": [
     "cordovaBuildTarget",
-    "devServerTarget",
-    "platform"
+    "devServerTarget"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -32,11 +32,11 @@
   "dependencies": {
     "@schematics/angular": "^7.0.3",
     "tslib": "^1.9.0",
-    "typescript": "~3.1.0"
+    "typescript": "^3.2.4"
   },
   "devDependencies": {
-    "@angular-devkit/architect": "^0.11.3",
-    "@angular-devkit/build-angular": "^0.11.3",
+    "@angular-devkit/architect": "^0.12.3",
+    "@angular-devkit/build-angular": "^0.12.3",
     "@angular-devkit/core": "^7.1.3",
     "@angular-devkit/schematics": "^7.1.3",
     "@semantic-release/changelog": "^3.0.0",


### PR DESCRIPTION
Add support for adding a blank `cordova.js` to the build with `--cordova-mock`.