### PR TITLE
chore(builders): updates deps for angular-builder

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,10 +35,10 @@
     "typescript": "^3.2.4"
   },
   "devDependencies": {
-    "@angular-devkit/architect": "^0.12.3",
-    "@angular-devkit/build-angular": "^0.12.3",
-    "@angular-devkit/core": "~7.2.0",
-    "@angular-devkit/schematics": "~7.2.0",
+    "@angular-devkit/architect": "0.13.1",
+    "@angular-devkit/build-angular": "0.13.1",
+    "@angular-devkit/core": "7.3.1",
+    "@angular-devkit/schematics": "7.3.1",
     "@semantic-release/changelog": "^3.0.0",
     "@semantic-release/git": "^7.0.4",
     "@semantic-release/github": "^5.0.6",


### PR DESCRIPTION
Updates deps for angular builders.

This update does add a deprecation warning for `Builder`, which will be refactored in the upcoming 8.0 release of Angular.


ref #75 
