### PR TITLE
Default sourceMap to empty object

### DIFF
--- a/builders/cordova-build/index.ts
+++ b/builders/cordova-build/index.ts
@@ -47,7 +47,7 @@ export class CordovaBuildBuilder implements Builder<CordovaBuildBuilderSchema> {
   prepareBrowserConfig(options: CordovaBuildBuilderSchema, browserOptions: BrowserBuilderSchema) {
     const cordovaBasePath = normalize(options.cordovaBasePath ? options.cordovaBasePath : '.');
 
-    browserOptions.sourceMap = options.sourceMap as any;
+    browserOptions.sourceMap = options.sourceMap || {} as any;
 
     // We always need to output the build to `www` because it is a hard
     // requirement of Cordova.

--- a/builders/cordova-build/index.ts
+++ b/builders/cordova-build/index.ts
@@ -47,7 +47,9 @@ export class CordovaBuildBuilder implements Builder<CordovaBuildBuilderSchema> {
   prepareBrowserConfig(options: CordovaBuildBuilderSchema, browserOptions: BrowserBuilderSchema) {
     const cordovaBasePath = normalize(options.cordovaBasePath ? options.cordovaBasePath : '.');
 
-    browserOptions.sourceMap = options.sourceMap || {} as any;
+    if (typeof options.sourceMap !== 'undefined' && options.sourceMap != null) {
+        browserOptions.sourceMap = options.sourceMap as any;
+    }
 
     // We always need to output the build to `www` because it is a hard
     // requirement of Cordova.

--- a/builders/cordova-build/index.ts
+++ b/builders/cordova-build/index.ts
@@ -47,7 +47,7 @@ export class CordovaBuildBuilder implements Builder<CordovaBuildBuilderSchema> {
   prepareBrowserConfig(options: CordovaBuildBuilderSchema, browserOptions: BrowserBuilderSchema) {
     const cordovaBasePath = normalize(options.cordovaBasePath ? options.cordovaBasePath : '.');
 
-    if (typeof options.sourceMap !== 'undefined' && options.sourceMap != null) {
+    if (typeof options.sourceMap !== 'undefined') {
         browserOptions.sourceMap = options.sourceMap as any;
     }
 


### PR DESCRIPTION
Latest sourceMap option update breaks when we DON'T specific the `--sourcemap` option.

That's because we set `browserOptions.sourceMap` to `options.sourceMap` which is null or undefined.

Error stacktrace:

```
[ng] Cannot destructure property `styles` of 'undefined' or 'null'.
[ng] TypeError: Cannot destructure property `styles` of 'undefined' or 'null'.
[ng]     at Object.getCommonConfig (/…/node_modules/@angular-devkit/build-angular/src/angular-cli-files/models/webpack-configs/common.js:33:107)
[ng]     at BrowserBuilder.buildWebpackConfig (/…/node_modules/@angular-devkit/build-angular/src/browser/index.js:81:31)
[ng]     at CordovaDevServerBuilder.buildWebpackConfig (/…/node_modules/@angular-devkit/build-angular/src/dev-server/index.js:109:46)
[ng]     at CordovaDevServerBuilder.buildWebpackConfig (/…/node_modules/@ionic/angular-toolkit/builders/cordova-serve/index.js:47:22)
[ng]     at MergeMapSubscriber.rxjs_1.from.pipe.operators_1.concatMap [as project] (/…/node_modules/@angular-devkit/build-angular/src/dev-server/index.js:36:40)
[ng]     at MergeMapSubscriber._tryNext (/…/node_modules/rxjs/internal/operators/mergeMap.js:69:27)
[ng]     at MergeMapSubscriber._next (/…/node_modules/rxjs/internal/operators/mergeMap.js:59:18)
[ng]     at MergeMapSubscriber.Subscriber.next (/…/node_modules/rxjs/internal/Subscriber.js:67:18)
[ng]     at TapSubscriber._next (/…/node_modules/rxjs/internal/operators/tap.js:65:26)
[ng]     at TapSubscriber.Subscriber.next (/…/node_modules/rxjs/internal/Subscriber.js:67:18)
[ng]     at MergeMapSubscriber.notifyNext (/…/node_modules/rxjs/internal/operators/mergeMap.js:92:26)
[ng]     at InnerSubscriber._next (/…/node_modules/rxjs/internal/InnerSubscriber.js:28:21)
[ng]     at InnerSubscriber.Subscriber.next (/…/node_modules/rxjs/internal/Subscriber.js:67:18)
[ng]     at MergeMapSubscriber.notifyNext (/…/node_modules/rxjs/internal/operators/mergeMap.js:92:26)
[ng]     at InnerSubscriber._next (/…/node_modules/rxjs/internal/InnerSubscriber.js:28:21)
[ng]     at InnerSubscriber.Subscriber.next (/…/node_modules/rxjs/internal/Subscriber.js:67:18)
```

Fixes https://github.com/ionic-team/angular-toolkit/issues/109