### PR TITLE
fix(unit-tests): allow the components to hydrate

### DIFF
--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,0 +1,8 @@
+const micromatch = require('micromatch')
+module.exports = {
+  '*.{ts,tsx}': files => {
+    const match = micromatch.not(files, '**/__tests__/*.{ts,tsx}')
+    return match.map(file => 'npm run lint')
+  }
+}
+

--- a/package.json
+++ b/package.json
@@ -71,14 +71,6 @@
       "pre-commit": "lint-staged"
     }
   },
-  "lint-staged": {
-    "linters": {
-      "*.{ts,tsx}": "npm run lint"
-    },
-    "ignore": [
-      "**/__tests__/*.{ts,tsx}"
-    ]
-  },
   "release": {
     "branch": "stable",
     "verifyConditions": [

--- a/schematics/component/files/__name@dasherize@if-flat__/__name@dasherize__.component.spec.ts
+++ b/schematics/component/files/__name@dasherize@if-flat__/__name@dasherize__.component.spec.ts
@@ -1,5 +1,5 @@
-import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { IonicModule } from '@ionic/angular';
 
 import { <%= classify(name) %>Component } from './<%= dasherize(name) %>.component';
 
@@ -10,16 +10,13 @@ describe('<%= classify(name) %>Component', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [ <%= classify(name) %>Component ],
-      schemas: [CUSTOM_ELEMENTS_SCHEMA],
-    })
-    .compileComponents();
-  }));
+      imports: [IonicModule.forRoot()]
+    }).compileComponents();
 
-  beforeEach(() => {
     fixture = TestBed.createComponent(<%= classify(name) %>Component);
     component = fixture.componentInstance;
     fixture.detectChanges();
-  });
+  }));
 
   it('should create', () => {
     expect(component).toBeTruthy();

--- a/schematics/page/files/__name@dasherize@if-flat__/__name@dasherize__.page.spec.ts
+++ b/schematics/page/files/__name@dasherize@if-flat__/__name@dasherize__.page.spec.ts
@@ -1,5 +1,5 @@
-import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { IonicModule } from '@ionic/angular';
 
 import { <%= classify(name) %>Page } from './<%= dasherize(name) %>.page';
 
@@ -10,16 +10,13 @@ describe('<%= classify(name) %>Page', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [ <%= classify(name) %>Page ],
-      schemas: [CUSTOM_ELEMENTS_SCHEMA],
-    })
-    .compileComponents();
-  }));
+      imports: [IonicModule.forRoot()]
+    }).compileComponents();
 
-  beforeEach(() => {
     fixture = TestBed.createComponent(<%= classify(name) %>Page);
     component = fixture.componentInstance;
     fixture.detectChanges();
-  });
+  }));
 
   it('should create', () => {
     expect(component).toBeTruthy();


### PR DESCRIPTION
Updated how the tests are set up in the starters such that the Ionic components hydrate. The thread of discussion for this can be found here: https://ionicteam.slack.com/archives/C7CGXAVTL/p1564506798491300


Also updates the lint pre-commit hook per some discussions with Dan on getting the commit to work.