### PR TITLE
fix(utils) always initialize scripts array

### DIFF
--- a/builders/utils/index.ts
+++ b/builders/utils/index.ts
@@ -46,6 +46,12 @@ export function prepareBrowserConfig(
     optionsStarter.deleteOutputPath = false;
   }
 
+  // Initialize an empty script array to make sure assets are pushed even when
+  // scripts is not configured in angular.json
+  if (!optionsStarter.scripts) {
+    optionsStarter.scripts = [];
+  }
+
   if (options.consolelogs) {
     // Write the config to a file, and then include that in the bundle so it loads on window
     const configPath = getSystemPath(
@@ -61,9 +67,6 @@ export function prepareBrowserConfig(
         options.consolelogsPort
       } }`
     );
-    if (!optionsStarter.scripts) {
-      optionsStarter.scripts = [];
-    }
     optionsStarter.scripts.push({
         input: configPath,
         bundleName: 'consolelogs',


### PR DESCRIPTION
In our project we were experiencing issues of a missing `cordova.js` file after upgrading to Angular 8. After some searching around it seems like we were having the same issue as mentioned in #179 .

Thing is: we were already using the latest version of angular-toolkit, which included the fix https://github.com/ionic-team/angular-toolkit/commit/0aeec9750ccbe4ec37f668e7839f3f438bb9f688 . 

It seems like the fix only initializes the `scripts` array with an empty array when `consolelogs` is used. In our project it isn't, which causes the `scripts` array to remain `null` and thus preventing the `cordova.js` from being injected. 

- Moving the check/initializer outside the `consolelogs` statement resolves the issue of a missing `cordova.js`.