### PR TITLE
feat(page): add `--create-module` option

### DIFF
--- a/schematics/page/index.ts
+++ b/schematics/page/index.ts
@@ -163,6 +163,7 @@ export default function(options: PageOptions): Rule {
 
     const templateSource = apply(url('./files'), [
       options.spec ? noop() : filter(p => !p.endsWith('.spec.ts')),
+      options.createModule ? noop() : filter(p => !p.endsWith('.module.ts')),
       template({
         ...strings,
         'if-flat': (s: string) => options.flat ? '' : s,
@@ -173,7 +174,7 @@ export default function(options: PageOptions): Rule {
 
     return chain([
       branchAndMerge(chain([
-        addRouteToNgModule(options),
+        options.createModule ? addRouteToNgModule(options) : noop(),
         mergeWith(templateSource),
       ])),
     ])(host, context);

--- a/schematics/page/schema.d.ts
+++ b/schematics/page/schema.d.ts
@@ -7,6 +7,7 @@ export interface Schema {
   spec?: boolean;
   flat?: boolean;
   selector?: string;
+  createModule?: boolean;
   module?: string;
   routePath?: string;
 }

--- a/schematics/page/schema.json
+++ b/schematics/page/schema.json
@@ -59,6 +59,11 @@
       "format": "html-selector",
       "description": "The selector to use for the page"
     },
+    "createModule":  {
+      "type": "boolean",
+      "description": "Allows creating an NgModule for the page",
+      "default": true
+    },
     "module":  {
       "type": "string",
       "description": "Allows specification of the declaring module",


### PR DESCRIPTION
Aligning the page schematic with the component schematic, which already offers `--create-module`. The default for the page schematic is `true`, unlike the component schematic. To disable module creation, `--create-module=false` must be specified.

fixes https://github.com/ionic-team/ionic-cli/issues/3586