### PR TITLE
feat(test): update async to waitForAsync

### DIFF
--- a/schematics/component/files/__name@dasherize@if-flat__/__name@dasherize__.component.spec.ts
+++ b/schematics/component/files/__name@dasherize@if-flat__/__name@dasherize__.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { IonicModule } from '@ionic/angular';
 
 import { <%= classify(name) %>Component } from './<%= dasherize(name) %>.component';
@@ -7,7 +7,7 @@ describe('<%= classify(name) %>Component', () => {
   let component: <%= classify(name) %>Component;
   let fixture: ComponentFixture<<%= classify(name) %>Component>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ <%= classify(name) %>Component ],
       imports: [IonicModule.forRoot()]

--- a/schematics/page/files/__name@dasherize@if-flat__/__name@dasherize__.page.spec.ts
+++ b/schematics/page/files/__name@dasherize@if-flat__/__name@dasherize__.page.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { IonicModule } from '@ionic/angular';
 
 import { <%= classify(name) %>Page } from './<%= dasherize(name) %>.page';
@@ -7,7 +7,7 @@ describe('<%= classify(name) %>Page', () => {
   let component: <%= classify(name) %>Page;
   let fixture: ComponentFixture<<%= classify(name) %>Page>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ <%= classify(name) %>Page ],
       imports: [IonicModule.forRoot()]


### PR DESCRIPTION
In Angular 10.1.0, waitForAsync() has replaced async() to avoid confusion.
https://github.com/angular/angular/pull/37583

And will be removed entirely in version 12.