### PR TITLE
build(deps): update Angular from 11.1.0 to 11.2.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,9 +6,9 @@
   "packages": {
     "": {
       "name": "@ionic/angular-toolkit",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "dependencies": {
-        "@schematics/angular": "^11.1.0",
+        "@schematics/angular": "^11.2.4",
         "cheerio": "1.0.0-rc.3",
         "colorette": "1.1.0",
         "copy-webpack-plugin": "^6.2.1",
@@ -17,12 +17,12 @@
         "ws": "^7.0.1"
       },
       "devDependencies": {
-        "@angular-devkit/architect": "^0.1101.0",
-        "@angular-devkit/build-angular": "^0.1101.0",
-        "@angular-devkit/core": "^11.1.0",
-        "@angular-devkit/schematics": "^11.1.0",
-        "@angular/compiler": "^11.1.0",
-        "@angular/compiler-cli": "^11.1.0",
+        "@angular-devkit/architect": "^0.1102.4",
+        "@angular-devkit/build-angular": "^0.1102.4",
+        "@angular-devkit/core": "^11.2.4",
+        "@angular-devkit/schematics": "^11.2.4",
+        "@angular/compiler": "^11.2.5",
+        "@angular/compiler-cli": "^11.2.5",
         "@ionic/eslint-config": "^0.3.0",
         "@ionic/prettier-config": "^1.0.1",
         "@semantic-release/changelog": "^3.0.0",
@@ -56,73 +56,56 @@
         "typescript-eslint-language-service": "^4.1.3"
       },
       "peerDependencies": {
-        "@angular-devkit/architect": "^0.1101.0",
-        "@angular-devkit/build-angular": "^0.1101.0",
-        "@angular-devkit/core": "^11.1.0",
-        "@angular-devkit/schematics": "^11.1.0"
+        "@angular-devkit/architect": "^0.1102.4",
+        "@angular-devkit/build-angular": "^0.1102.4",
+        "@angular-devkit/core": "^11.2.4",
+        "@angular-devkit/schematics": "^11.2.4"
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.1101.2",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1101.2.tgz",
-      "integrity": "sha512-MLmBfHiiyPhbFSSAX4oMecPjEuBauOui5uBpI6BKNnk/7783fznbkbAKjXlOco7M81gkNeEoHMR8c+mOfcvv7g==",
+      "version": "0.1102.4",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1102.4.tgz",
+      "integrity": "sha512-A/nc/s9S9+H6xFOxcXqyfiCg9lXzCpO2ZVeaNamZB8f8tHoGfFMQ3JkCGhFiYsbze4fXhcwszNq1o36lGIW7FA==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "11.1.2",
+        "@angular-devkit/core": "11.2.4",
         "rxjs": "6.6.3"
       },
       "engines": {
         "node": ">= 10.13.0",
-        "npm": ">= 6.11.0",
-        "yarn": ">= 1.13.0"
-      }
-    },
-    "node_modules/@angular-devkit/architect/node_modules/@angular-devkit/core": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-11.1.2.tgz",
-      "integrity": "sha512-V7zOMqL2l56JcwXVyswkG+7+t67r9XtkrVzRcG2Z5ZYwafU+iKWMwg5kBFZr1SX7fM1M9E4MpskxqtagQeUKng==",
-      "dev": true,
-      "dependencies": {
-        "ajv": "6.12.6",
-        "fast-json-stable-stringify": "2.1.0",
-        "magic-string": "0.25.7",
-        "rxjs": "6.6.3",
-        "source-map": "0.7.3"
-      },
-      "engines": {
-        "node": ">= 10.13.0",
-        "npm": ">= 6.11.0",
+        "npm": "^6.11.0 || ^7.5.6",
         "yarn": ">= 1.13.0"
       }
     },
     "node_modules/@angular-devkit/build-angular": {
-      "version": "0.1101.2",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-0.1101.2.tgz",
-      "integrity": "sha512-EVJ7kAgy+sMnliCmHwN1niVeM7YaAvTMkF+ahImNfQRSQOW+QJ4F8vjiLtuARC6R02Yc5QPzELTHVPxC4Qll/A==",
+      "version": "0.1102.4",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-0.1102.4.tgz",
+      "integrity": "sha512-/t39b+fXDG5kwJGovtGF6K4Vg55BvVz2IJbeVurpplg2pJp5cpSUhQAe0mXcvjkvle/ZLIfYP0Ahdh/7VahuGg==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/architect": "0.1101.2",
-        "@angular-devkit/build-optimizer": "0.1101.2",
-        "@angular-devkit/build-webpack": "0.1101.2",
-        "@angular-devkit/core": "11.1.2",
+        "@angular-devkit/architect": "0.1102.4",
+        "@angular-devkit/build-optimizer": "0.1102.4",
+        "@angular-devkit/build-webpack": "0.1102.4",
+        "@angular-devkit/core": "11.2.4",
         "@babel/core": "7.12.10",
         "@babel/generator": "7.12.11",
+        "@babel/plugin-transform-async-to-generator": "7.12.1",
         "@babel/plugin-transform-runtime": "7.12.10",
         "@babel/preset-env": "7.12.11",
         "@babel/runtime": "7.12.5",
         "@babel/template": "7.12.7",
         "@jsdevtools/coverage-istanbul-loader": "3.0.5",
-        "@ngtools/webpack": "11.1.2",
+        "@ngtools/webpack": "11.2.4",
         "ansi-colors": "4.1.1",
-        "autoprefixer": "10.2.1",
+        "autoprefixer": "10.2.4",
         "babel-loader": "8.2.2",
         "browserslist": "^4.9.1",
         "cacache": "15.0.5",
         "caniuse-lite": "^1.0.30001032",
         "circular-dependency-plugin": "5.2.2",
         "copy-webpack-plugin": "6.3.2",
-        "core-js": "3.8.2",
-        "critters": "0.0.6",
+        "core-js": "3.8.3",
+        "critters": "0.0.7",
         "css-loader": "5.0.1",
         "cssnano": "4.1.10",
         "file-loader": "6.2.0",
@@ -132,14 +115,14 @@
         "inquirer": "7.3.3",
         "jest-worker": "26.6.2",
         "karma-source-map-support": "1.4.0",
-        "less": "4.1.0",
+        "less": "4.1.1",
         "less-loader": "7.3.0",
         "license-webpack-plugin": "2.3.11",
         "loader-utils": "2.0.0",
-        "mini-css-extract-plugin": "1.3.3",
+        "mini-css-extract-plugin": "1.3.5",
         "minimatch": "3.0.4",
-        "open": "7.3.1",
-        "ora": "5.2.0",
+        "open": "7.4.0",
+        "ora": "5.3.0",
         "parse5-html-rewriting-stream": "6.0.1",
         "pnp-webpack-plugin": "1.6.4",
         "postcss": "8.2.4",
@@ -149,25 +132,25 @@
         "regenerator-runtime": "0.13.7",
         "resolve-url-loader": "3.1.2",
         "rimraf": "3.0.2",
-        "rollup": "2.36.1",
+        "rollup": "2.38.4",
         "rxjs": "6.6.3",
-        "sass": "1.32.4",
+        "sass": "1.32.6",
         "sass-loader": "10.1.1",
         "semver": "7.3.4",
         "source-map": "0.7.3",
         "source-map-loader": "1.1.3",
         "source-map-support": "0.5.19",
-        "speed-measure-webpack-plugin": "1.3.3",
+        "speed-measure-webpack-plugin": "1.4.2",
         "style-loader": "2.0.0",
         "stylus": "0.54.8",
-        "stylus-loader": "4.3.2",
+        "stylus-loader": "4.3.3",
         "terser": "5.5.1",
         "terser-webpack-plugin": "4.2.3",
         "text-table": "0.2.0",
         "tree-kill": "1.2.2",
         "webpack": "4.44.2",
         "webpack-dev-middleware": "3.7.2",
-        "webpack-dev-server": "3.11.1",
+        "webpack-dev-server": "3.11.2",
         "webpack-merge": "5.7.3",
         "webpack-sources": "2.2.0",
         "webpack-subresource-integrity": "1.5.2",
@@ -175,26 +158,56 @@
       },
       "engines": {
         "node": ">= 10.13.0",
-        "npm": ">= 6.11.0",
+        "npm": "^6.11.0 || ^7.5.6",
         "yarn": ">= 1.13.0"
+      },
+      "peerDependencies": {
+        "@angular/compiler-cli": "^11.0.0 || ^11.2.0-next",
+        "@angular/localize": "^11.0.0 || ^11.2.0-next",
+        "@angular/service-worker": "^11.0.0 || ^11.2.0-next",
+        "karma": "^5.2.0 || ^6.0.0",
+        "ng-packagr": "^11.0.0 || ^11.2.0-next",
+        "protractor": "^7.0.0",
+        "tailwindcss": "^2.0.0",
+        "tslint": "^6.1.0",
+        "typescript": "~4.0.0 || ~4.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@angular/localize": {
+          "optional": true
+        },
+        "@angular/service-worker": {
+          "optional": true
+        },
+        "karma": {
+          "optional": true
+        },
+        "ng-packagr": {
+          "optional": true
+        },
+        "protractor": {
+          "optional": true
+        },
+        "tailwindcss": {
+          "optional": true
+        },
+        "tslint": {
+          "optional": true
+        }
       }
     },
-    "node_modules/@angular-devkit/build-angular/node_modules/@angular-devkit/core": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-11.1.2.tgz",
-      "integrity": "sha512-V7zOMqL2l56JcwXVyswkG+7+t67r9XtkrVzRcG2Z5ZYwafU+iKWMwg5kBFZr1SX7fM1M9E4MpskxqtagQeUKng==",
+    "node_modules/@angular-devkit/build-angular/node_modules/@babel/plugin-transform-async-to-generator": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.12.1.tgz",
+      "integrity": "sha512-SDtqoEcarK1DFlRJ1hHRY5HvJUj5kX4qmtpMAm2QnhOlyuMC4TMdCRgW6WXpv93rZeYNeLP22y8Aq2dbcDRM1A==",
       "dev": true,
       "dependencies": {
-        "ajv": "6.12.6",
-        "fast-json-stable-stringify": "2.1.0",
-        "magic-string": "0.25.7",
-        "rxjs": "6.6.3",
-        "source-map": "0.7.3"
+        "@babel/helper-module-imports": "^7.12.1",
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/helper-remap-async-to-generator": "^7.12.1"
       },
-      "engines": {
-        "node": ">= 10.13.0",
-        "npm": ">= 6.11.0",
-        "yarn": ">= 1.13.0"
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@angular-devkit/build-angular/node_modules/copy-webpack-plugin": {
@@ -279,15 +292,15 @@
       }
     },
     "node_modules/@angular-devkit/build-optimizer": {
-      "version": "0.1101.2",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-optimizer/-/build-optimizer-0.1101.2.tgz",
-      "integrity": "sha512-ARcUcEwaAR3n0gUq2hCx4eXONdnKKXTYSaw2GUHtraBDp+m/vFcE6Ufxyki453eHbHtaQ9yjXOcBqu86u1u8hA==",
+      "version": "0.1102.4",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-optimizer/-/build-optimizer-0.1102.4.tgz",
+      "integrity": "sha512-8jsF1L11tcPJCvEdMxLctPz+D479vuh8voBqlm3I7RnYXvXpNzdZqGrJbTnq6zg1/7cxS1+g6qHmne8TwFl0bw==",
       "dev": true,
       "dependencies": {
         "loader-utils": "2.0.0",
         "source-map": "0.7.3",
         "tslib": "2.1.0",
-        "typescript": "4.1.3",
+        "typescript": "4.1.5",
         "webpack-sources": "2.2.0"
       },
       "bin": {
@@ -295,14 +308,14 @@
       },
       "engines": {
         "node": ">= 10.13.0",
-        "npm": ">= 6.11.0",
+        "npm": "^6.11.0 || ^7.5.6",
         "yarn": ">= 1.13.0"
       }
     },
     "node_modules/@angular-devkit/build-optimizer/node_modules/typescript": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
-      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
+      "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -313,43 +326,29 @@
       }
     },
     "node_modules/@angular-devkit/build-webpack": {
-      "version": "0.1101.2",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1101.2.tgz",
-      "integrity": "sha512-T8+LjKdxk1faQA4Dh3PYkRbIBLE6Tjv5SNZmdDXpvGoyxS9FmLgLDXQZqXkYgiAHwH6PxhoQX4iVxkHHFkkHog==",
+      "version": "0.1102.4",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1102.4.tgz",
+      "integrity": "sha512-AENmPesqy51JAePlBBOoc+WEGT28ytIPxPeagUxDjA+MXMY8wggbejzXq/mDFy+rEUi0cUSPramixTXDLjz+mA==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/architect": "0.1101.2",
-        "@angular-devkit/core": "11.1.2",
+        "@angular-devkit/architect": "0.1102.4",
+        "@angular-devkit/core": "11.2.4",
         "rxjs": "6.6.3"
       },
       "engines": {
         "node": ">= 10.13.0",
-        "npm": ">= 6.11.0",
+        "npm": "^6.11.0 || ^7.5.6",
         "yarn": ">= 1.13.0"
-      }
-    },
-    "node_modules/@angular-devkit/build-webpack/node_modules/@angular-devkit/core": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-11.1.2.tgz",
-      "integrity": "sha512-V7zOMqL2l56JcwXVyswkG+7+t67r9XtkrVzRcG2Z5ZYwafU+iKWMwg5kBFZr1SX7fM1M9E4MpskxqtagQeUKng==",
-      "dev": true,
-      "dependencies": {
-        "ajv": "6.12.6",
-        "fast-json-stable-stringify": "2.1.0",
-        "magic-string": "0.25.7",
-        "rxjs": "6.6.3",
-        "source-map": "0.7.3"
       },
-      "engines": {
-        "node": ">= 10.13.0",
-        "npm": ">= 6.11.0",
-        "yarn": ">= 1.13.0"
+      "peerDependencies": {
+        "webpack": "^4.6.0",
+        "webpack-dev-server": "^3.1.4"
       }
     },
     "node_modules/@angular-devkit/core": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-11.2.0.tgz",
-      "integrity": "sha512-qqYEH8m/bwpngoLDMFuth8ykvoHxQ3aHHnAWfRXz9NXydwSfathG0VSYCctB126sK39JKIn+xq16CQAExxNu+Q==",
+      "version": "11.2.4",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-11.2.4.tgz",
+      "integrity": "sha512-98mGDV4XtKWiQ/2D6yzvOHrnJovXchaAN9AjscAHd2an8Fkiq72d9m2wREpk+2J40NWTDB6J5iesTh3qbi8+CA==",
       "dependencies": {
         "ajv": "6.12.6",
         "fast-json-stable-stringify": "2.1.0",
@@ -359,114 +358,39 @@
       },
       "engines": {
         "node": ">= 10.13.0",
-        "npm": "^6.11.0",
+        "npm": "^6.11.0 || ^7.5.6",
         "yarn": ">= 1.13.0"
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-11.2.0.tgz",
-      "integrity": "sha512-sMDacACJbA4pykiqgJf/RdW0damcf4mDqErGgEqs/bGG+SBUb8+wgt4cQnUwwVX5V2nMdvv7f0A84rgR6I3G2w==",
+      "version": "11.2.4",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-11.2.4.tgz",
+      "integrity": "sha512-M9Ike1TYawOIHzenlZS1ufQbsS+Z11/doj5w/UrU0q2OEKc6U375t5qVGgKo3PLHHS8osb9aW9xYwBfVlKrryQ==",
+      "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "11.2.0",
+        "@angular-devkit/core": "11.2.4",
         "ora": "5.3.0",
         "rxjs": "6.6.3"
       },
       "engines": {
         "node": ">= 10.13.0",
-        "npm": "^6.11.0",
+        "npm": "^6.11.0 || ^7.5.6",
         "yarn": ">= 1.13.0"
       }
     },
-    "node_modules/@angular-devkit/schematics/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@angular-devkit/schematics/node_modules/chalk": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-      "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@angular-devkit/schematics/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@angular-devkit/schematics/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
-    "node_modules/@angular-devkit/schematics/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@angular-devkit/schematics/node_modules/ora": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-5.3.0.tgz",
-      "integrity": "sha512-zAKMgGXUim0Jyd6CXK9lraBnD3H5yPGBPPOkC23a2BG6hsm4Zu6OQSjQuEtV0BHDf4aKHcUFvJiGRrFuW3MG8g==",
-      "dependencies": {
-        "bl": "^4.0.3",
-        "chalk": "^4.1.0",
-        "cli-cursor": "^3.1.0",
-        "cli-spinners": "^2.5.0",
-        "is-interactive": "^1.0.0",
-        "log-symbols": "^4.0.0",
-        "strip-ansi": "^6.0.0",
-        "wcwidth": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@angular-devkit/schematics/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@angular/compiler": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-11.2.0.tgz",
-      "integrity": "sha512-EW6LM/kUYhQkuFqGt03c/eRKZAYr0LLEdMOn//j1uIh+wSq9KLffBGpky6b63xdfWxsXi8OucXUOydTQBckNEQ==",
+      "version": "11.2.5",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-11.2.5.tgz",
+      "integrity": "sha512-MrgZnTY6OPooDZw76wgj1ZM43IwwStsDfwuvYI8B7PR+QtPIwAkxi+spW78MHy3ltzsIQorC98pMiz7c7oTxDg==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.0.0"
       }
     },
     "node_modules/@angular/compiler-cli": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-11.2.0.tgz",
-      "integrity": "sha512-FJ8OHWBQftmncDGV43ASFeCu3cW1W2P5fvub9fiBFEeTIkB/HXrMOMCQg/1XSdfA5kwFzj2NedMp573X9kq6ng==",
+      "version": "11.2.5",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-11.2.5.tgz",
+      "integrity": "sha512-pSKyLIV9kn6tRugMPXo9t3QXSMbHVGUGw7wEoRwRrsqJ+JbU10Ke+sMsPF8ewqpsX+sslzx5TqD+1thXhhkBsQ==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.8.6",
@@ -493,6 +417,10 @@
       },
       "engines": {
         "node": ">=10.0"
+      },
+      "peerDependencies": {
+        "@angular/compiler": "11.2.5",
+        "typescript": ">=4.0 <4.2"
       }
     },
     "node_modules/@angular/compiler-cli/node_modules/semver": {
@@ -1964,37 +1892,24 @@
       }
     },
     "node_modules/@ngtools/webpack": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-11.1.2.tgz",
-      "integrity": "sha512-x/HVx4doKu4gAwGGk+C89JCFe5GF8Te7I7uvwMTqEXr+Ua9YHYvN/q2IwLdhIXPB4ilBSIjrb9zm05yBvBTAeg==",
+      "version": "11.2.4",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-11.2.4.tgz",
+      "integrity": "sha512-BVhYydfYGZuLXcTpzWeI9ONguwnkCmxP6lRIEyvRYTuGshSsK8v5itBrect7D1cIxnT/a+aZbVWIF1qWeQdepw==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "11.1.2",
-        "enhanced-resolve": "5.6.0",
+        "@angular-devkit/core": "11.2.4",
+        "enhanced-resolve": "5.7.0",
         "webpack-sources": "2.2.0"
       },
       "engines": {
         "node": ">= 10.13.0",
-        "npm": ">= 6.11.0",
+        "npm": "^6.11.0 || ^7.5.6",
         "yarn": ">= 1.13.0"
-      }
-    },
-    "node_modules/@ngtools/webpack/node_modules/@angular-devkit/core": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-11.1.2.tgz",
-      "integrity": "sha512-V7zOMqL2l56JcwXVyswkG+7+t67r9XtkrVzRcG2Z5ZYwafU+iKWMwg5kBFZr1SX7fM1M9E4MpskxqtagQeUKng==",
-      "dev": true,
-      "dependencies": {
-        "ajv": "6.12.6",
-        "fast-json-stable-stringify": "2.1.0",
-        "magic-string": "0.25.7",
-        "rxjs": "6.6.3",
-        "source-map": "0.7.3"
       },
-      "engines": {
-        "node": ">= 10.13.0",
-        "npm": ">= 6.11.0",
-        "yarn": ">= 1.13.0"
+      "peerDependencies": {
+        "@angular/compiler-cli": "^11.0.0 || ^11.2.0-next",
+        "typescript": "~4.0.0 || ~4.1.0",
+        "webpack": "^4.0.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -2204,17 +2119,17 @@
       }
     },
     "node_modules/@schematics/angular": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-11.2.0.tgz",
-      "integrity": "sha512-PtbyZ7TEEEae9Y5siSZYigWyk8iOSjZ10ThA7tRxm8gdcLjGimyyKr5TyjufIAvrXIYnBXNLgPkZG6s5CQIEyw==",
+      "version": "11.2.4",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-11.2.4.tgz",
+      "integrity": "sha512-HKWpcmfJfx5fryDdVGN1s+AmzOCKViQQGrEZmDTC2PhA6Vg+SOeMKesyFvdOqf4Ld1ZNYw9Kg94wrpz6rycP/Q==",
       "dependencies": {
-        "@angular-devkit/core": "11.2.0",
-        "@angular-devkit/schematics": "11.2.0",
+        "@angular-devkit/core": "11.2.4",
+        "@angular-devkit/schematics": "11.2.4",
         "jsonc-parser": "3.0.0"
       },
       "engines": {
         "node": ">= 10.13.0",
-        "npm": "^6.11.0",
+        "npm": "^6.11.0 || ^7.5.6",
         "yarn": ">= 1.13.0"
       }
     },
@@ -3510,13 +3425,13 @@
       "dev": true
     },
     "node_modules/autoprefixer": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.2.1.tgz",
-      "integrity": "sha512-dwP0UjyYvROUvtU+boBx8ff5pPWami1NGTrJs9YUsS/oZVbRAcdNHOOuXSA1fc46tgKqe072cVaKD69rvCc3QQ==",
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.2.4.tgz",
+      "integrity": "sha512-DCCdUQiMD+P/as8m3XkeTUkUKuuRqLGcwD0nll7wevhqoJfMRpJlkFd1+MQh1pvupjiQuip42lc/VFvfUTMSKw==",
       "dev": true,
       "dependencies": {
         "browserslist": "^4.16.1",
-        "caniuse-lite": "^1.0.30001173",
+        "caniuse-lite": "^1.0.30001181",
         "colorette": "^1.2.1",
         "fraction.js": "^4.0.13",
         "normalize-range": "^0.1.2",
@@ -3527,6 +3442,13 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
       }
     },
     "node_modules/autoprefixer/node_modules/colorette": {
@@ -4167,7 +4089,6 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.3.1",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -4594,7 +4515,6 @@
       "integrity": "sha512-yAYxeGpVi27hqIilG1nh4A9Bnx4J3Ov+eXy4koL3drrR+IO9GaWPsKjik20ht608Asqi8TQPf0mczhEeyAtMzg==",
       "dev": true,
       "dependencies": {
-        "@commitlint/load": ">6.1.1",
         "chalk": "^2.4.1",
         "commitizen": "^4.0.3",
         "conventional-commit-types": "^3.0.0",
@@ -5252,10 +5172,15 @@
       }
     },
     "node_modules/core-js": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.8.2.tgz",
-      "integrity": "sha512-FfApuSRgrR6G5s58casCBd9M2k+4ikuu4wbW6pJyYU7bd9zvFc9qf7vr5xmrZOhT9nn+8uwlH1oRR9jTnFoA3A==",
-      "dev": true
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.8.3.tgz",
+      "integrity": "sha512-KPYXeVZYemC2TkNEkX/01I+7yd+nX3KddKwZ1Ww7SKWdI2wQprSgLmrTddT8nw92AjEklTsPBoSdQBhbI1bQ6Q==",
+      "dev": true,
+      "hasInstallScript": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
     },
     "node_modules/core-js-compat": {
       "version": "3.8.3",
@@ -5341,9 +5266,9 @@
       }
     },
     "node_modules/critters": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/critters/-/critters-0.0.6.tgz",
-      "integrity": "sha512-NUB3Om7tkf+XWi9+2kJ2A3l4/tHORDI1UT+nHxUqay2B/tJvMpiXcklDDLBH3fPn9Pe23uu0we/08Ukjy4cLCQ==",
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/critters/-/critters-0.0.7.tgz",
+      "integrity": "sha512-qUF2SaAWFYjNPdCcPpu68p2DnHiosia84yx5mPTlUMQjkjChR+n6sO1/I7yn2U2qNDgSPTd2SoaTIDQcUL+EwQ==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.1.0",
@@ -5363,6 +5288,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/critters/node_modules/chalk": {
@@ -5376,6 +5304,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/critters/node_modules/color-convert": {
@@ -5942,7 +5873,6 @@
       "integrity": "sha512-U466fIzU5U22eES5lTNiNbZ+d8dfcHcssH4o7QsdWaCcRs/feIPCxKYSWkYBNs5mny7MvEfwpTLWjvbm94hecw==",
       "dev": true,
       "dependencies": {
-        "@commitlint/load": ">6.1.1",
         "chalk": "^2.4.1",
         "commitizen": "^4.0.3",
         "conventional-commit-types": "^3.0.0",
@@ -6055,6 +5985,9 @@
         "object-is": "^1.0.1",
         "object-keys": "^1.1.1",
         "regexp.prototype.flags": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/deep-extend": {
@@ -6750,9 +6683,9 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.6.0.tgz",
-      "integrity": "sha512-C3GGDfFZmqUa21o10YRKbZN60DPl0HyXKXxoEnQMWso9u7KMU23L7CBHfr/rVxORddY/8YQZaU2MZ1ewTS8Pcw==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.7.0.tgz",
+      "integrity": "sha512-6njwt/NsZFUKhM6j9U8hzVyD4E4r0x7NQzhTCbcWOJ0IQjNSAoalWmb0AE51Wn+fwan5qVESWi7t2ToBxs9vrw==",
       "dev": true,
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -8720,7 +8653,6 @@
         "minimist": "^1.2.5",
         "neo-async": "^2.6.0",
         "source-map": "^0.6.1",
-        "uglify-js": "^3.1.4",
         "wordwrap": "^1.0.0"
       },
       "bin": {
@@ -9597,6 +9529,9 @@
       },
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/import-local/node_modules/p-locate": {
@@ -9845,6 +9780,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-arrayish": {
@@ -9957,6 +9895,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-extendable": {
@@ -10776,20 +10717,13 @@
       }
     },
     "node_modules/less": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/less/-/less-4.1.0.tgz",
-      "integrity": "sha512-w1Ag/f34g7LwtQ/sMVSGWIyZx+gG9ZOAEtyxeX1fG75is6BMyC2lD5kG+1RueX7PkAvlQBm2Lf2aN2j0JbVr2A==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/less/-/less-4.1.1.tgz",
+      "integrity": "sha512-w09o8tZFPThBscl5d0Ggp3RcrKIouBoQscnOMgFH3n5V3kN/CXGHNfCkRPtxJk6nKryDXaV9aHLK55RXuH4sAw==",
       "dev": true,
       "dependencies": {
         "copy-anything": "^2.0.1",
-        "errno": "^0.1.1",
-        "graceful-fs": "^4.1.2",
-        "image-size": "~0.5.0",
-        "make-dir": "^2.1.0",
-        "mime": "^1.4.1",
-        "needle": "^2.5.2",
         "parse-node-version": "^1.0.1",
-        "source-map": "~0.6.0",
         "tslib": "^1.10.0"
       },
       "bin": {
@@ -10799,6 +10733,8 @@
         "node": ">=6"
       },
       "optionalDependencies": {
+        "errno": "^0.1.1",
+        "graceful-fs": "^4.1.2",
         "image-size": "~0.5.0",
         "make-dir": "^2.1.0",
         "mime": "^1.4.1",
@@ -11519,6 +11455,10 @@
       "dev": true,
       "engines": {
         "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
       }
     },
     "node_modules/longest": {
@@ -11982,9 +11922,9 @@
       }
     },
     "node_modules/mini-css-extract-plugin": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-1.3.3.tgz",
-      "integrity": "sha512-7lvliDSMiuZc81kI+5/qxvn47SCM7BehXex3f2c6l/pR3Goj58IQxZh9nuPQ3AkGQgoETyXuIqLDaO5Oa0TyBw==",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-1.3.5.tgz",
+      "integrity": "sha512-tvmzcwqJJXau4OQE5vT72pRT18o2zF+tQJp8CWchqvfQnTlflkzS+dANYcRdyPRWUWRkfmeNTKltx0NZI/b5dQ==",
       "dev": true,
       "dependencies": {
         "loader-utils": "^2.0.0",
@@ -11993,6 +11933,13 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^4.4.0 || ^5.0.0"
       }
     },
     "node_modules/mini-css-extract-plugin/node_modules/schema-utils": {
@@ -12007,6 +11954,10 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/mini-css-extract-plugin/node_modules/source-map": {
@@ -13520,7 +13471,6 @@
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "colors": "^1.1.2",
         "object-assign": "^4.1.0",
         "string-width": "^2.1.1"
       },
@@ -16810,7 +16760,6 @@
       "license": "ISC",
       "dependencies": {
         "debuglog": "^1.0.1",
-        "graceful-fs": "^4.1.2",
         "read-package-json": "^2.0.0",
         "readdir-scoped-modules": "^1.0.0",
         "semver": "2 || 3 || 4 || 5",
@@ -16830,7 +16779,6 @@
       "license": "ISC",
       "dependencies": {
         "glob": "^7.1.1",
-        "graceful-fs": "^4.1.2",
         "json-parse-better-errors": "^1.0.1",
         "normalize-package-data": "^2.0.0",
         "npm-normalize-package-bin": "^1.0.0"
@@ -17299,13 +17247,9 @@
       "dependencies": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
         "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
         "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
+        "safer-buffer": "^2.0.2"
       },
       "bin": {
         "sshpk-conv": "bin/sshpk-conv",
@@ -18400,16 +18344,19 @@
       "dev": true
     },
     "node_modules/object-is": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.4.tgz",
-      "integrity": "sha512-1ZvAZ4wlF7IyPVOcE1Omikt7UpaFlOQq0HlSti+ZvDH3UiD2brwGMwDbyV43jao2bKJ+4+WdPJHSd7kgzKYVqg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
+      "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
       "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.0",
+        "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/object-keys": {
@@ -18557,9 +18504,9 @@
       }
     },
     "node_modules/open": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/open/-/open-7.3.1.tgz",
-      "integrity": "sha512-f2wt9DCBKKjlFbjzGb8MOAW8LH8F0mrs1zc7KTjAJ9PZNQbfenzWbNP1VZJvw6ICMG9r14Ah6yfwPn7T7i646A==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.0.tgz",
+      "integrity": "sha512-PGoBCX/lclIWlpS/R2PQuIR4NJoXh6X5AwVzE7WXnWRGvHg7+4TBCgsujUgiPpm0K1y4qvQeWnCWVTpTKZBtvA==",
       "dev": true,
       "dependencies": {
         "is-docker": "^2.0.0",
@@ -18567,6 +18514,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/opencollective-postinstall": {
@@ -18617,10 +18567,9 @@
       }
     },
     "node_modules/ora": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-5.2.0.tgz",
-      "integrity": "sha512-+wG2v8TUU8EgzPHun1k/n45pXquQ9fHnbXVetl9rRgO6kjZszGGbraF3XPTIdgeA+s1lbRjSEftAnyT0w8ZMvQ==",
-      "dev": true,
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.3.0.tgz",
+      "integrity": "sha512-zAKMgGXUim0Jyd6CXK9lraBnD3H5yPGBPPOkC23a2BG6hsm4Zu6OQSjQuEtV0BHDf4aKHcUFvJiGRrFuW3MG8g==",
       "dependencies": {
         "bl": "^4.0.3",
         "chalk": "^4.1.0",
@@ -18633,38 +18582,44 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ora/node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/ora/node_modules/chalk": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
       "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/ora/node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -18675,14 +18630,12 @@
     "node_modules/ora/node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/ora/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -18691,7 +18644,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -20962,6 +20914,9 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/process": {
@@ -21469,6 +21424,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/regexpp": {
@@ -21897,13 +21855,10 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.36.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.36.1.tgz",
-      "integrity": "sha512-eAfqho8dyzuVvrGqpR0ITgEdq0zG2QJeWYh+HeuTbpcaXk8vNFc48B7bJa1xYosTCKx0CuW+447oQOW8HgBIZQ==",
+      "version": "2.38.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.38.4.tgz",
+      "integrity": "sha512-B0LcJhjiwKkTl79aGVF/u5KdzsH8IylVfV56Ut6c9ouWLJcUK17T83aZBetNYSnZtXf2OHD4+2PbmRW+Fp5ulg==",
       "dev": true,
-      "dependencies": {
-        "fsevents": "~2.1.2"
-      },
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -21911,20 +21866,7 @@
         "node": ">=10.0.0"
       },
       "optionalDependencies": {
-        "fsevents": "~2.1.2"
-      }
-    },
-    "node_modules/rollup/node_modules/fsevents": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
-      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+        "fsevents": "~2.3.1"
       }
     },
     "node_modules/run-async": {
@@ -21990,9 +21932,9 @@
       "dev": true
     },
     "node_modules/sass": {
-      "version": "1.32.4",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.32.4.tgz",
-      "integrity": "sha512-N0BT0PI/t3+gD8jKa83zJJUb7ssfQnRRfqN+GIErokW6U4guBpfYl8qYB+OFLEho+QvnV5ZH1R9qhUC/Z2Ch9w==",
+      "version": "1.32.6",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.32.6.tgz",
+      "integrity": "sha512-1bcDHDcSqeFtMr0JXI3xc/CXX6c4p0wHHivJdru8W7waM7a1WjKMm4m/Z5sY7CbVw4Whi2Chpcw6DFfSWwGLzQ==",
       "dev": true,
       "dependencies": {
         "chokidar": ">=2.0.0 <4.0.0"
@@ -23288,15 +23230,88 @@
       }
     },
     "node_modules/speed-measure-webpack-plugin": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/speed-measure-webpack-plugin/-/speed-measure-webpack-plugin-1.3.3.tgz",
-      "integrity": "sha512-2ljD4Ch/rz2zG3HsLsnPfp23osuPBS0qPuz9sGpkNXTN1Ic4M+W9xB8l8rS8ob2cO4b1L+WTJw/0AJwWYVgcxQ==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/speed-measure-webpack-plugin/-/speed-measure-webpack-plugin-1.4.2.tgz",
+      "integrity": "sha512-AtVzD0bnIy2/B0fWqJpJgmhcrfWFhBlduzSo0uwplr/QvB33ZNZj2NEth3NONgdnZJqicK0W0mSxnLSbsVCDbw==",
       "dev": true,
       "dependencies": {
-        "chalk": "^2.0.1"
+        "chalk": "^4.1.0"
       },
       "engines": {
         "node": ">=6.0.0"
+      },
+      "peerDependencies": {
+        "webpack": "^1 || ^2 || ^3 || ^4 || ^5"
+      }
+    },
+    "node_modules/speed-measure-webpack-plugin/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/speed-measure-webpack-plugin/node_modules/chalk": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+      "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/speed-measure-webpack-plugin/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/speed-measure-webpack-plugin/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/speed-measure-webpack-plugin/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/speed-measure-webpack-plugin/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/split": {
@@ -23929,9 +23944,9 @@
       }
     },
     "node_modules/stylus-loader": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/stylus-loader/-/stylus-loader-4.3.2.tgz",
-      "integrity": "sha512-xXVKHY+J7GBlOmqjCL1VvQfc+pFkBdWGtcpJSvBGE49nWWHaukox7KCjRdLTEzjrmHODm4+rLpqkYWzfJteMXQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/stylus-loader/-/stylus-loader-4.3.3.tgz",
+      "integrity": "sha512-PpWB5PnCXUzW4WMYhCvNzAHJBjIBPMXwsdfkkKuA9W7k8OQFMl/19/AQvaWsxz2IptxUlCseyJ6TY/eEKJ4+UQ==",
       "dev": true,
       "dependencies": {
         "fast-glob": "^3.2.4",
@@ -23942,6 +23957,14 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "stylus": ">=0.52.4",
+        "webpack": "^4.0.0 || ^5.0.0"
       }
     },
     "node_modules/stylus-loader/node_modules/schema-utils": {
@@ -23956,6 +23979,10 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/stylus/node_modules/debug": {
@@ -24948,9 +24975,9 @@
       "dev": true
     },
     "node_modules/url-parse": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
-      "integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.1.tgz",
+      "integrity": "sha512-HOfCOUJt7iSYzEx/UqgtwKRMC6EU91NFhsCHMv9oM03VJcVo2Qrp8T8kI9D7amFf1cu+/3CEhgb3rF9zL7k85Q==",
       "dev": true,
       "dependencies": {
         "querystringify": "^2.1.1",
@@ -25098,8 +25125,7 @@
       "dependencies": {
         "chokidar": "^3.4.1",
         "graceful-fs": "^4.1.2",
-        "neo-async": "^2.5.0",
-        "watchpack-chokidar2": "^2.0.1"
+        "neo-async": "^2.5.0"
       },
       "optionalDependencies": {
         "watchpack-chokidar2": "^2.0.1"
@@ -25479,6 +25505,9 @@
       },
       "engines": {
         "node": ">= 6"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
       }
     },
     "node_modules/webpack-dev-middleware/node_modules/mkdirp": {
@@ -25494,9 +25523,9 @@
       }
     },
     "node_modules/webpack-dev-server": {
-      "version": "3.11.1",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.11.1.tgz",
-      "integrity": "sha512-u4R3mRzZkbxQVa+MBWi2uVpB5W59H3ekZAJsQlKUTdl7Elcah2EhygTPLmeFXybQkf9i2+L0kn7ik9SnXa6ihQ==",
+      "version": "3.11.2",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.11.2.tgz",
+      "integrity": "sha512-A80BkuHRQfCiNtGBS1EMf2ChTUs0x+B3wGDFmOeT4rmJOHhHTCH2naNxIHhmkr0/UillP4U3yeIyv1pNp+QDLQ==",
       "dev": true,
       "dependencies": {
         "ansi-html": "0.0.7",
@@ -25538,6 +25567,14 @@
       },
       "engines": {
         "node": ">= 6.11.5"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0 || ^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "webpack-cli": {
+          "optional": true
+        }
       }
     },
     "node_modules/webpack-dev-server/node_modules/ansi-regex": {
@@ -25626,12 +25663,12 @@
       "version": "2.1.8",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
       "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
+      "deprecated": "Chokidar 2 will break on node v14+. Upgrade to chokidar 3 with 15x less dependencies.",
       "dev": true,
       "dependencies": {
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
-        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
@@ -25726,7 +25763,9 @@
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
       "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+      "deprecated": "fsevents 1 will break on node v14+ and could be using insecure binaries. Upgrade to fsevents 2.",
       "dev": true,
+      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"
@@ -25877,6 +25916,9 @@
       },
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/webpack-dev-server/node_modules/p-locate": {
@@ -27134,58 +27176,44 @@
   },
   "dependencies": {
     "@angular-devkit/architect": {
-      "version": "0.1101.2",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1101.2.tgz",
-      "integrity": "sha512-MLmBfHiiyPhbFSSAX4oMecPjEuBauOui5uBpI6BKNnk/7783fznbkbAKjXlOco7M81gkNeEoHMR8c+mOfcvv7g==",
+      "version": "0.1102.4",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1102.4.tgz",
+      "integrity": "sha512-A/nc/s9S9+H6xFOxcXqyfiCg9lXzCpO2ZVeaNamZB8f8tHoGfFMQ3JkCGhFiYsbze4fXhcwszNq1o36lGIW7FA==",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "11.1.2",
+        "@angular-devkit/core": "11.2.4",
         "rxjs": "6.6.3"
-      },
-      "dependencies": {
-        "@angular-devkit/core": {
-          "version": "11.1.2",
-          "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-11.1.2.tgz",
-          "integrity": "sha512-V7zOMqL2l56JcwXVyswkG+7+t67r9XtkrVzRcG2Z5ZYwafU+iKWMwg5kBFZr1SX7fM1M9E4MpskxqtagQeUKng==",
-          "dev": true,
-          "requires": {
-            "ajv": "6.12.6",
-            "fast-json-stable-stringify": "2.1.0",
-            "magic-string": "0.25.7",
-            "rxjs": "6.6.3",
-            "source-map": "0.7.3"
-          }
-        }
       }
     },
     "@angular-devkit/build-angular": {
-      "version": "0.1101.2",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-0.1101.2.tgz",
-      "integrity": "sha512-EVJ7kAgy+sMnliCmHwN1niVeM7YaAvTMkF+ahImNfQRSQOW+QJ4F8vjiLtuARC6R02Yc5QPzELTHVPxC4Qll/A==",
+      "version": "0.1102.4",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-0.1102.4.tgz",
+      "integrity": "sha512-/t39b+fXDG5kwJGovtGF6K4Vg55BvVz2IJbeVurpplg2pJp5cpSUhQAe0mXcvjkvle/ZLIfYP0Ahdh/7VahuGg==",
       "dev": true,
       "requires": {
-        "@angular-devkit/architect": "0.1101.2",
-        "@angular-devkit/build-optimizer": "0.1101.2",
-        "@angular-devkit/build-webpack": "0.1101.2",
-        "@angular-devkit/core": "11.1.2",
+        "@angular-devkit/architect": "0.1102.4",
+        "@angular-devkit/build-optimizer": "0.1102.4",
+        "@angular-devkit/build-webpack": "0.1102.4",
+        "@angular-devkit/core": "11.2.4",
         "@babel/core": "7.12.10",
         "@babel/generator": "7.12.11",
+        "@babel/plugin-transform-async-to-generator": "7.12.1",
         "@babel/plugin-transform-runtime": "7.12.10",
         "@babel/preset-env": "7.12.11",
         "@babel/runtime": "7.12.5",
         "@babel/template": "7.12.7",
         "@jsdevtools/coverage-istanbul-loader": "3.0.5",
-        "@ngtools/webpack": "11.1.2",
+        "@ngtools/webpack": "11.2.4",
         "ansi-colors": "4.1.1",
-        "autoprefixer": "10.2.1",
+        "autoprefixer": "10.2.4",
         "babel-loader": "8.2.2",
         "browserslist": "^4.9.1",
         "cacache": "15.0.5",
         "caniuse-lite": "^1.0.30001032",
         "circular-dependency-plugin": "5.2.2",
         "copy-webpack-plugin": "6.3.2",
-        "core-js": "3.8.2",
-        "critters": "0.0.6",
+        "core-js": "3.8.3",
+        "critters": "0.0.7",
         "css-loader": "5.0.1",
         "cssnano": "4.1.10",
         "file-loader": "6.2.0",
@@ -27195,14 +27223,14 @@
         "inquirer": "7.3.3",
         "jest-worker": "26.6.2",
         "karma-source-map-support": "1.4.0",
-        "less": "4.1.0",
+        "less": "4.1.1",
         "less-loader": "7.3.0",
         "license-webpack-plugin": "2.3.11",
         "loader-utils": "2.0.0",
-        "mini-css-extract-plugin": "1.3.3",
+        "mini-css-extract-plugin": "1.3.5",
         "minimatch": "3.0.4",
-        "open": "7.3.1",
-        "ora": "5.2.0",
+        "open": "7.4.0",
+        "ora": "5.3.0",
         "parse5-html-rewriting-stream": "6.0.1",
         "pnp-webpack-plugin": "1.6.4",
         "postcss": "8.2.4",
@@ -27212,42 +27240,40 @@
         "regenerator-runtime": "0.13.7",
         "resolve-url-loader": "3.1.2",
         "rimraf": "3.0.2",
-        "rollup": "2.36.1",
+        "rollup": "2.38.4",
         "rxjs": "6.6.3",
-        "sass": "1.32.4",
+        "sass": "1.32.6",
         "sass-loader": "10.1.1",
         "semver": "7.3.4",
         "source-map": "0.7.3",
         "source-map-loader": "1.1.3",
         "source-map-support": "0.5.19",
-        "speed-measure-webpack-plugin": "1.3.3",
+        "speed-measure-webpack-plugin": "1.4.2",
         "style-loader": "2.0.0",
         "stylus": "0.54.8",
-        "stylus-loader": "4.3.2",
+        "stylus-loader": "4.3.3",
         "terser": "5.5.1",
         "terser-webpack-plugin": "4.2.3",
         "text-table": "0.2.0",
         "tree-kill": "1.2.2",
         "webpack": "4.44.2",
         "webpack-dev-middleware": "3.7.2",
-        "webpack-dev-server": "3.11.1",
+        "webpack-dev-server": "3.11.2",
         "webpack-merge": "5.7.3",
         "webpack-sources": "2.2.0",
         "webpack-subresource-integrity": "1.5.2",
         "worker-plugin": "5.0.0"
       },
       "dependencies": {
-        "@angular-devkit/core": {
-          "version": "11.1.2",
-          "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-11.1.2.tgz",
-          "integrity": "sha512-V7zOMqL2l56JcwXVyswkG+7+t67r9XtkrVzRcG2Z5ZYwafU+iKWMwg5kBFZr1SX7fM1M9E4MpskxqtagQeUKng==",
+        "@babel/plugin-transform-async-to-generator": {
+          "version": "7.12.1",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.12.1.tgz",
+          "integrity": "sha512-SDtqoEcarK1DFlRJ1hHRY5HvJUj5kX4qmtpMAm2QnhOlyuMC4TMdCRgW6WXpv93rZeYNeLP22y8Aq2dbcDRM1A==",
           "dev": true,
           "requires": {
-            "ajv": "6.12.6",
-            "fast-json-stable-stringify": "2.1.0",
-            "magic-string": "0.25.7",
-            "rxjs": "6.6.3",
-            "source-map": "0.7.3"
+            "@babel/helper-module-imports": "^7.12.1",
+            "@babel/helper-plugin-utils": "^7.10.4",
+            "@babel/helper-remap-async-to-generator": "^7.12.1"
           }
         },
         "copy-webpack-plugin": {
@@ -27321,56 +27347,41 @@
       }
     },
     "@angular-devkit/build-optimizer": {
-      "version": "0.1101.2",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-optimizer/-/build-optimizer-0.1101.2.tgz",
-      "integrity": "sha512-ARcUcEwaAR3n0gUq2hCx4eXONdnKKXTYSaw2GUHtraBDp+m/vFcE6Ufxyki453eHbHtaQ9yjXOcBqu86u1u8hA==",
+      "version": "0.1102.4",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-optimizer/-/build-optimizer-0.1102.4.tgz",
+      "integrity": "sha512-8jsF1L11tcPJCvEdMxLctPz+D479vuh8voBqlm3I7RnYXvXpNzdZqGrJbTnq6zg1/7cxS1+g6qHmne8TwFl0bw==",
       "dev": true,
       "requires": {
         "loader-utils": "2.0.0",
         "source-map": "0.7.3",
         "tslib": "2.1.0",
-        "typescript": "4.1.3",
+        "typescript": "4.1.5",
         "webpack-sources": "2.2.0"
       },
       "dependencies": {
         "typescript": {
-          "version": "4.1.3",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
-          "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
+          "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==",
           "dev": true
         }
       }
     },
     "@angular-devkit/build-webpack": {
-      "version": "0.1101.2",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1101.2.tgz",
-      "integrity": "sha512-T8+LjKdxk1faQA4Dh3PYkRbIBLE6Tjv5SNZmdDXpvGoyxS9FmLgLDXQZqXkYgiAHwH6PxhoQX4iVxkHHFkkHog==",
+      "version": "0.1102.4",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1102.4.tgz",
+      "integrity": "sha512-AENmPesqy51JAePlBBOoc+WEGT28ytIPxPeagUxDjA+MXMY8wggbejzXq/mDFy+rEUi0cUSPramixTXDLjz+mA==",
       "dev": true,
       "requires": {
-        "@angular-devkit/architect": "0.1101.2",
-        "@angular-devkit/core": "11.1.2",
+        "@angular-devkit/architect": "0.1102.4",
+        "@angular-devkit/core": "11.2.4",
         "rxjs": "6.6.3"
-      },
-      "dependencies": {
-        "@angular-devkit/core": {
-          "version": "11.1.2",
-          "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-11.1.2.tgz",
-          "integrity": "sha512-V7zOMqL2l56JcwXVyswkG+7+t67r9XtkrVzRcG2Z5ZYwafU+iKWMwg5kBFZr1SX7fM1M9E4MpskxqtagQeUKng==",
-          "dev": true,
-          "requires": {
-            "ajv": "6.12.6",
-            "fast-json-stable-stringify": "2.1.0",
-            "magic-string": "0.25.7",
-            "rxjs": "6.6.3",
-            "source-map": "0.7.3"
-          }
-        }
       }
     },
     "@angular-devkit/core": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-11.2.0.tgz",
-      "integrity": "sha512-qqYEH8m/bwpngoLDMFuth8ykvoHxQ3aHHnAWfRXz9NXydwSfathG0VSYCctB126sK39JKIn+xq16CQAExxNu+Q==",
+      "version": "11.2.4",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-11.2.4.tgz",
+      "integrity": "sha512-98mGDV4XtKWiQ/2D6yzvOHrnJovXchaAN9AjscAHd2an8Fkiq72d9m2wREpk+2J40NWTDB6J5iesTh3qbi8+CA==",
       "requires": {
         "ajv": "6.12.6",
         "fast-json-stable-stringify": "2.1.0",
@@ -27380,88 +27391,28 @@
       }
     },
     "@angular-devkit/schematics": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-11.2.0.tgz",
-      "integrity": "sha512-sMDacACJbA4pykiqgJf/RdW0damcf4mDqErGgEqs/bGG+SBUb8+wgt4cQnUwwVX5V2nMdvv7f0A84rgR6I3G2w==",
+      "version": "11.2.4",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-11.2.4.tgz",
+      "integrity": "sha512-M9Ike1TYawOIHzenlZS1ufQbsS+Z11/doj5w/UrU0q2OEKc6U375t5qVGgKo3PLHHS8osb9aW9xYwBfVlKrryQ==",
       "requires": {
-        "@angular-devkit/core": "11.2.0",
+        "@angular-devkit/core": "11.2.4",
         "ora": "5.3.0",
         "rxjs": "6.6.3"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-        },
-        "ora": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/ora/-/ora-5.3.0.tgz",
-          "integrity": "sha512-zAKMgGXUim0Jyd6CXK9lraBnD3H5yPGBPPOkC23a2BG6hsm4Zu6OQSjQuEtV0BHDf4aKHcUFvJiGRrFuW3MG8g==",
-          "requires": {
-            "bl": "^4.0.3",
-            "chalk": "^4.1.0",
-            "cli-cursor": "^3.1.0",
-            "cli-spinners": "^2.5.0",
-            "is-interactive": "^1.0.0",
-            "log-symbols": "^4.0.0",
-            "strip-ansi": "^6.0.0",
-            "wcwidth": "^1.0.1"
-          }
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
       }
     },
     "@angular/compiler": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-11.2.0.tgz",
-      "integrity": "sha512-EW6LM/kUYhQkuFqGt03c/eRKZAYr0LLEdMOn//j1uIh+wSq9KLffBGpky6b63xdfWxsXi8OucXUOydTQBckNEQ==",
+      "version": "11.2.5",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-11.2.5.tgz",
+      "integrity": "sha512-MrgZnTY6OPooDZw76wgj1ZM43IwwStsDfwuvYI8B7PR+QtPIwAkxi+spW78MHy3ltzsIQorC98pMiz7c7oTxDg==",
       "dev": true,
       "requires": {
         "tslib": "^2.0.0"
       }
     },
     "@angular/compiler-cli": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-11.2.0.tgz",
-      "integrity": "sha512-FJ8OHWBQftmncDGV43ASFeCu3cW1W2P5fvub9fiBFEeTIkB/HXrMOMCQg/1XSdfA5kwFzj2NedMp573X9kq6ng==",
+      "version": "11.2.5",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-11.2.5.tgz",
+      "integrity": "sha512-pSKyLIV9kn6tRugMPXo9t3QXSMbHVGUGw7wEoRwRrsqJ+JbU10Ke+sMsPF8ewqpsX+sslzx5TqD+1thXhhkBsQ==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.8.6",
@@ -28874,29 +28825,14 @@
       }
     },
     "@ngtools/webpack": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-11.1.2.tgz",
-      "integrity": "sha512-x/HVx4doKu4gAwGGk+C89JCFe5GF8Te7I7uvwMTqEXr+Ua9YHYvN/q2IwLdhIXPB4ilBSIjrb9zm05yBvBTAeg==",
+      "version": "11.2.4",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-11.2.4.tgz",
+      "integrity": "sha512-BVhYydfYGZuLXcTpzWeI9ONguwnkCmxP6lRIEyvRYTuGshSsK8v5itBrect7D1cIxnT/a+aZbVWIF1qWeQdepw==",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "11.1.2",
-        "enhanced-resolve": "5.6.0",
+        "@angular-devkit/core": "11.2.4",
+        "enhanced-resolve": "5.7.0",
         "webpack-sources": "2.2.0"
-      },
-      "dependencies": {
-        "@angular-devkit/core": {
-          "version": "11.1.2",
-          "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-11.1.2.tgz",
-          "integrity": "sha512-V7zOMqL2l56JcwXVyswkG+7+t67r9XtkrVzRcG2Z5ZYwafU+iKWMwg5kBFZr1SX7fM1M9E4MpskxqtagQeUKng==",
-          "dev": true,
-          "requires": {
-            "ajv": "6.12.6",
-            "fast-json-stable-stringify": "2.1.0",
-            "magic-string": "0.25.7",
-            "rxjs": "6.6.3",
-            "source-map": "0.7.3"
-          }
-        }
       }
     },
     "@nodelib/fs.scandir": {
@@ -29104,12 +29040,12 @@
       }
     },
     "@schematics/angular": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-11.2.0.tgz",
-      "integrity": "sha512-PtbyZ7TEEEae9Y5siSZYigWyk8iOSjZ10ThA7tRxm8gdcLjGimyyKr5TyjufIAvrXIYnBXNLgPkZG6s5CQIEyw==",
+      "version": "11.2.4",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-11.2.4.tgz",
+      "integrity": "sha512-HKWpcmfJfx5fryDdVGN1s+AmzOCKViQQGrEZmDTC2PhA6Vg+SOeMKesyFvdOqf4Ld1ZNYw9Kg94wrpz6rycP/Q==",
       "requires": {
-        "@angular-devkit/core": "11.2.0",
-        "@angular-devkit/schematics": "11.2.0",
+        "@angular-devkit/core": "11.2.4",
+        "@angular-devkit/schematics": "11.2.4",
         "jsonc-parser": "3.0.0"
       }
     },
@@ -30263,13 +30199,13 @@
       "dev": true
     },
     "autoprefixer": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.2.1.tgz",
-      "integrity": "sha512-dwP0UjyYvROUvtU+boBx8ff5pPWami1NGTrJs9YUsS/oZVbRAcdNHOOuXSA1fc46tgKqe072cVaKD69rvCc3QQ==",
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.2.4.tgz",
+      "integrity": "sha512-DCCdUQiMD+P/as8m3XkeTUkUKuuRqLGcwD0nll7wevhqoJfMRpJlkFd1+MQh1pvupjiQuip42lc/VFvfUTMSKw==",
       "dev": true,
       "requires": {
         "browserslist": "^4.16.1",
-        "caniuse-lite": "^1.0.30001173",
+        "caniuse-lite": "^1.0.30001181",
         "colorette": "^1.2.1",
         "fraction.js": "^4.0.13",
         "normalize-range": "^0.1.2",
@@ -31749,9 +31685,9 @@
       }
     },
     "core-js": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.8.2.tgz",
-      "integrity": "sha512-FfApuSRgrR6G5s58casCBd9M2k+4ikuu4wbW6pJyYU7bd9zvFc9qf7vr5xmrZOhT9nn+8uwlH1oRR9jTnFoA3A==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.8.3.tgz",
+      "integrity": "sha512-KPYXeVZYemC2TkNEkX/01I+7yd+nX3KddKwZ1Ww7SKWdI2wQprSgLmrTddT8nw92AjEklTsPBoSdQBhbI1bQ6Q==",
       "dev": true
     },
     "core-js-compat": {
@@ -31836,9 +31772,9 @@
       }
     },
     "critters": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/critters/-/critters-0.0.6.tgz",
-      "integrity": "sha512-NUB3Om7tkf+XWi9+2kJ2A3l4/tHORDI1UT+nHxUqay2B/tJvMpiXcklDDLBH3fPn9Pe23uu0we/08Ukjy4cLCQ==",
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/critters/-/critters-0.0.7.tgz",
+      "integrity": "sha512-qUF2SaAWFYjNPdCcPpu68p2DnHiosia84yx5mPTlUMQjkjChR+n6sO1/I7yn2U2qNDgSPTd2SoaTIDQcUL+EwQ==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.0",
@@ -33038,9 +32974,9 @@
       }
     },
     "enhanced-resolve": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.6.0.tgz",
-      "integrity": "sha512-C3GGDfFZmqUa21o10YRKbZN60DPl0HyXKXxoEnQMWso9u7KMU23L7CBHfr/rVxORddY/8YQZaU2MZ1ewTS8Pcw==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.7.0.tgz",
+      "integrity": "sha512-6njwt/NsZFUKhM6j9U8hzVyD4E4r0x7NQzhTCbcWOJ0IQjNSAoalWmb0AE51Wn+fwan5qVESWi7t2ToBxs9vrw==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.2.4",
@@ -36355,9 +36291,9 @@
       "dev": true
     },
     "less": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/less/-/less-4.1.0.tgz",
-      "integrity": "sha512-w1Ag/f34g7LwtQ/sMVSGWIyZx+gG9ZOAEtyxeX1fG75is6BMyC2lD5kG+1RueX7PkAvlQBm2Lf2aN2j0JbVr2A==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/less/-/less-4.1.1.tgz",
+      "integrity": "sha512-w09o8tZFPThBscl5d0Ggp3RcrKIouBoQscnOMgFH3n5V3kN/CXGHNfCkRPtxJk6nKryDXaV9aHLK55RXuH4sAw==",
       "dev": true,
       "requires": {
         "copy-anything": "^2.0.1",
@@ -37340,9 +37276,9 @@
       "dev": true
     },
     "mini-css-extract-plugin": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-1.3.3.tgz",
-      "integrity": "sha512-7lvliDSMiuZc81kI+5/qxvn47SCM7BehXex3f2c6l/pR3Goj58IQxZh9nuPQ3AkGQgoETyXuIqLDaO5Oa0TyBw==",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-1.3.5.tgz",
+      "integrity": "sha512-tvmzcwqJJXau4OQE5vT72pRT18o2zF+tQJp8CWchqvfQnTlflkzS+dANYcRdyPRWUWRkfmeNTKltx0NZI/b5dQ==",
       "dev": true,
       "requires": {
         "loader-utils": "^2.0.0",
@@ -42330,12 +42266,12 @@
       "dev": true
     },
     "object-is": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.4.tgz",
-      "integrity": "sha512-1ZvAZ4wlF7IyPVOcE1Omikt7UpaFlOQq0HlSti+ZvDH3UiD2brwGMwDbyV43jao2bKJ+4+WdPJHSd7kgzKYVqg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
+      "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
       "dev": true,
       "requires": {
-        "call-bind": "^1.0.0",
+        "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
       }
     },
@@ -42454,9 +42390,9 @@
       }
     },
     "open": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/open/-/open-7.3.1.tgz",
-      "integrity": "sha512-f2wt9DCBKKjlFbjzGb8MOAW8LH8F0mrs1zc7KTjAJ9PZNQbfenzWbNP1VZJvw6ICMG9r14Ah6yfwPn7T7i646A==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.0.tgz",
+      "integrity": "sha512-PGoBCX/lclIWlpS/R2PQuIR4NJoXh6X5AwVzE7WXnWRGvHg7+4TBCgsujUgiPpm0K1y4qvQeWnCWVTpTKZBtvA==",
       "dev": true,
       "requires": {
         "is-docker": "^2.0.0",
@@ -42501,10 +42437,9 @@
       }
     },
     "ora": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-5.2.0.tgz",
-      "integrity": "sha512-+wG2v8TUU8EgzPHun1k/n45pXquQ9fHnbXVetl9rRgO6kjZszGGbraF3XPTIdgeA+s1lbRjSEftAnyT0w8ZMvQ==",
-      "dev": true,
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.3.0.tgz",
+      "integrity": "sha512-zAKMgGXUim0Jyd6CXK9lraBnD3H5yPGBPPOkC23a2BG6hsm4Zu6OQSjQuEtV0BHDf4aKHcUFvJiGRrFuW3MG8g==",
       "requires": {
         "bl": "^4.0.3",
         "chalk": "^4.1.0",
@@ -42520,7 +42455,6 @@
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
           "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
           "requires": {
             "color-convert": "^2.0.1"
           }
@@ -42529,7 +42463,6 @@
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
           "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -42539,7 +42472,6 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
           "requires": {
             "color-name": "~1.1.4"
           }
@@ -42547,20 +42479,17 @@
         "color-name": {
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
         },
         "supports-color": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
           "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -45185,21 +45114,12 @@
       }
     },
     "rollup": {
-      "version": "2.36.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.36.1.tgz",
-      "integrity": "sha512-eAfqho8dyzuVvrGqpR0ITgEdq0zG2QJeWYh+HeuTbpcaXk8vNFc48B7bJa1xYosTCKx0CuW+447oQOW8HgBIZQ==",
+      "version": "2.38.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.38.4.tgz",
+      "integrity": "sha512-B0LcJhjiwKkTl79aGVF/u5KdzsH8IylVfV56Ut6c9ouWLJcUK17T83aZBetNYSnZtXf2OHD4+2PbmRW+Fp5ulg==",
       "dev": true,
       "requires": {
-        "fsevents": "~2.1.2"
-      },
-      "dependencies": {
-        "fsevents": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
-          "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
-          "dev": true,
-          "optional": true
-        }
+        "fsevents": "~2.3.1"
       }
     },
     "run-async": {
@@ -45261,9 +45181,9 @@
       "dev": true
     },
     "sass": {
-      "version": "1.32.4",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.32.4.tgz",
-      "integrity": "sha512-N0BT0PI/t3+gD8jKa83zJJUb7ssfQnRRfqN+GIErokW6U4guBpfYl8qYB+OFLEho+QvnV5ZH1R9qhUC/Z2Ch9w==",
+      "version": "1.32.6",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.32.6.tgz",
+      "integrity": "sha512-1bcDHDcSqeFtMr0JXI3xc/CXX6c4p0wHHivJdru8W7waM7a1WjKMm4m/Z5sY7CbVw4Whi2Chpcw6DFfSWwGLzQ==",
       "dev": true,
       "requires": {
         "chokidar": ">=2.0.0 <4.0.0"
@@ -46382,12 +46302,63 @@
       }
     },
     "speed-measure-webpack-plugin": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/speed-measure-webpack-plugin/-/speed-measure-webpack-plugin-1.3.3.tgz",
-      "integrity": "sha512-2ljD4Ch/rz2zG3HsLsnPfp23osuPBS0qPuz9sGpkNXTN1Ic4M+W9xB8l8rS8ob2cO4b1L+WTJw/0AJwWYVgcxQ==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/speed-measure-webpack-plugin/-/speed-measure-webpack-plugin-1.4.2.tgz",
+      "integrity": "sha512-AtVzD0bnIy2/B0fWqJpJgmhcrfWFhBlduzSo0uwplr/QvB33ZNZj2NEth3NONgdnZJqicK0W0mSxnLSbsVCDbw==",
       "dev": true,
       "requires": {
-        "chalk": "^2.0.1"
+        "chalk": "^4.1.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "split": {
@@ -46968,9 +46939,9 @@
       }
     },
     "stylus-loader": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/stylus-loader/-/stylus-loader-4.3.2.tgz",
-      "integrity": "sha512-xXVKHY+J7GBlOmqjCL1VvQfc+pFkBdWGtcpJSvBGE49nWWHaukox7KCjRdLTEzjrmHODm4+rLpqkYWzfJteMXQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/stylus-loader/-/stylus-loader-4.3.3.tgz",
+      "integrity": "sha512-PpWB5PnCXUzW4WMYhCvNzAHJBjIBPMXwsdfkkKuA9W7k8OQFMl/19/AQvaWsxz2IptxUlCseyJ6TY/eEKJ4+UQ==",
       "dev": true,
       "requires": {
         "fast-glob": "^3.2.4",
@@ -47793,9 +47764,9 @@
       "dev": true
     },
     "url-parse": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
-      "integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.1.tgz",
+      "integrity": "sha512-HOfCOUJt7iSYzEx/UqgtwKRMC6EU91NFhsCHMv9oM03VJcVo2Qrp8T8kI9D7amFf1cu+/3CEhgb3rF9zL7k85Q==",
       "dev": true,
       "requires": {
         "querystringify": "^2.1.1",
@@ -48708,9 +48679,9 @@
       }
     },
     "webpack-dev-server": {
-      "version": "3.11.1",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.11.1.tgz",
-      "integrity": "sha512-u4R3mRzZkbxQVa+MBWi2uVpB5W59H3ekZAJsQlKUTdl7Elcah2EhygTPLmeFXybQkf9i2+L0kn7ik9SnXa6ihQ==",
+      "version": "3.11.2",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.11.2.tgz",
+      "integrity": "sha512-A80BkuHRQfCiNtGBS1EMf2ChTUs0x+B3wGDFmOeT4rmJOHhHTCH2naNxIHhmkr0/UillP4U3yeIyv1pNp+QDLQ==",
       "dev": true,
       "requires": {
         "ansi-html": "0.0.7",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "ionicframework"
   ],
   "dependencies": {
-    "@schematics/angular": "^11.1.0",
+    "@schematics/angular": "^11.2.4",
     "cheerio": "1.0.0-rc.3",
     "colorette": "1.1.0",
     "copy-webpack-plugin": "^6.2.1",
@@ -41,12 +41,12 @@
     "ws": "^7.0.1"
   },
   "devDependencies": {
-    "@angular-devkit/architect": "^0.1101.0",
-    "@angular-devkit/build-angular": "^0.1101.0",
-    "@angular-devkit/core": "^11.1.0",
-    "@angular-devkit/schematics": "^11.1.0",
-    "@angular/compiler": "^11.1.0",
-    "@angular/compiler-cli": "^11.1.0",
+    "@angular-devkit/architect": "^0.1102.4",
+    "@angular-devkit/build-angular": "^0.1102.4",
+    "@angular-devkit/core": "^11.2.4",
+    "@angular-devkit/schematics": "^11.2.4",
+    "@angular/compiler": "^11.2.5",
+    "@angular/compiler-cli": "^11.2.5",
     "@ionic/eslint-config": "^0.3.0",
     "@ionic/prettier-config": "^1.0.1",
     "@semantic-release/changelog": "^3.0.0",
@@ -80,10 +80,10 @@
     "typescript-eslint-language-service": "^4.1.3"
   },
   "peerDependencies": {
-    "@angular-devkit/architect": "^0.1101.0",
-    "@angular-devkit/build-angular": "^0.1101.0",
-    "@angular-devkit/core": "^11.1.0",
-    "@angular-devkit/schematics": "^11.1.0"
+    "@angular-devkit/architect": "^0.1102.4",
+    "@angular-devkit/build-angular": "^0.1102.4",
+    "@angular-devkit/core": "^11.2.4",
+    "@angular-devkit/schematics": "^11.2.4"
   },
   "builders": "./builders.json",
   "schematics": "./collection.json",


### PR DESCRIPTION
Angular 11.2.0 was released the day PR #438 got merged.

EDIT: There are newer Angular 11.2 patch releases since this pull request was created, and I have updated the branch accordingly.