### PR TITLE
chore(package): add missing license field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@ionic/angular-toolkit",
   "version": "3.1.1",
+  "license": "MIT",
   "description": "Schematics and builders for @ionic/angular apps.",
   "homepage": "https://ionicframework.com/",
   "author": "Ionic Team <hi@ionicframework.com> (https://ionicframework.com)",


### PR DESCRIPTION
Adds the missing `MIT` license to the package json