### PR TITLE
refactor(schematics): extend from @schematics/angular at top level

### DIFF
--- a/packages/schematics/collection.json
+++ b/packages/schematics/collection.json
@@ -1,4 +1,5 @@
 {
+  "extends": ["@schematics/angular"],
   "schematics": {
     "page": {
       "aliases": ["pg"],
@@ -11,65 +12,6 @@
       "factory": "./component",
       "description": "Create an Angular component.",
       "schema": "./component/schema.json"
-    },
-    "class": {
-      "aliases": ["cl"],
-      "extends": "@schematics/angular:class"
-    },
-    "directive": {
-      "aliases": ["d"],
-      "extends": "@schematics/angular:directive"
-    },
-    "enum": {
-      "aliases": ["e"],
-      "extends": "@schematics/angular:enum"
-    },
-    "guard": {
-      "aliases": ["g"],
-      "extends": "@schematics/angular:guard"
-    },
-    "resolver": {
-      "aliases": ["r"],
-      "extends": "@schematics/angular:resolver"
-    },
-    "interface": {
-      "aliases": ["i"],
-      "extends": "@schematics/angular:interface"
-    },
-    "module": {
-      "aliases": ["m"],
-      "extends": "@schematics/angular:module"
-    },
-    "pipe": {
-      "aliases": ["p"],
-      "extends": "@schematics/angular:pipe"
-    },
-    "service": {
-      "aliases": ["s"],
-      "extends": "@schematics/angular:service"
-    },
-    "application": {
-      "aliases": ["app"],
-      "extends": "@schematics/angular:application"
-    },
-    "e2e": {
-      "extends": "@schematics/angular:e2e"
-    },
-    "library": {
-      "aliases": ["lib"],
-      "extends": "@schematics/angular:library"
-    },
-    "serviceWorker": {
-      "aliases": ["service-worker"],
-      "extends": "@schematics/angular:serviceWorker"
-    },
-    "appShell": {
-      "aliases": ["app-shell"],
-      "extends": "@schematics/angular:appShell"
-    },
-    "webWorker": {
-      "aliases": ["web-worker"],
-      "extends": "@schematics/angular:webWorker"
     }
   }
 }


### PR DESCRIPTION
This PR simplify the structure of `collection.json`.

By doing so, we no longer need to worry about upstream's @schematics/angular changing their schematics name (which cause issues, like #470) or adding a new one (no need to manually add new schematic, like #461)

Closes #470 
Closes https://github.com/ionic-team/ionic-cli/issues/4922