### PR TITLE
fix: remove extra parentheses with spec test

### DIFF
--- a/packages/schematics/page/files/__name@dasherize@if-flat__/__name@dasherize__.page.spec.ts
+++ b/packages/schematics/page/files/__name@dasherize@if-flat__/__name@dasherize__.page.spec.ts
@@ -5,7 +5,7 @@ describe('<%= classify(name) %>Page', () => {
   let component: <%= classify(name) %>Page;
   let fixture: ComponentFixture<<%= classify(name) %>Page>;
 
-  beforeEach(async() => {
+  beforeEach(async () => {
     fixture = TestBed.createComponent(<%= classify(name) %>Page);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/packages/schematics/page/files/__name@dasherize@if-flat__/__name@dasherize__.page.spec.ts
+++ b/packages/schematics/page/files/__name@dasherize@if-flat__/__name@dasherize__.page.spec.ts
@@ -5,11 +5,11 @@ describe('<%= classify(name) %>Page', () => {
   let component: <%= classify(name) %>Page;
   let fixture: ComponentFixture<<%= classify(name) %>Page>;
 
-  beforeEach(async(() => {
+  beforeEach(async() => {
     fixture = TestBed.createComponent(<%= classify(name) %>Page);
     component = fixture.componentInstance;
     fixture.detectChanges();
-  }));
+  });
 
   it('should create', () => {
     expect(component).toBeTruthy();


### PR DESCRIPTION
resolves #489 

There was an extra set of parentheses that was causing tests to fail on a syntax error.

```
Error: src/app/pages/home/home.page.spec.ts:8:14 - error TS2304: Cannot find name 'async'.

8   beforeEach(async(() => {
               ~~~~~
```

This was probably left over from our previous `waitForAsync` usage which was a function call: https://github.com/ionic-team/angular-toolkit/blob/6f5cc268b9402b4d7d83ca2d117036735b9e2041/packages/schematics/component/files/__name%40dasherize%40if-flat__/__name%40dasherize__.__type%40dasherize__.spec.ts.template#L10