### PR TITLE
fix(page): remove waitFromAsync from beforeEach

### DIFF
--- a/packages/schematics/page/files/__name@dasherize@if-flat__/__name@dasherize__.page.spec.ts
+++ b/packages/schematics/page/files/__name@dasherize@if-flat__/__name@dasherize__.page.spec.ts
@@ -5,7 +5,7 @@ describe('<%= classify(name) %>Page', () => {
   let component: <%= classify(name) %>Page;
   let fixture: ComponentFixture<<%= classify(name) %>Page>;
 
-  beforeEach(waitForAsync () => {
+  beforeEach(() => {
     fixture = TestBed.createComponent(<%= classify(name) %>Page);
     component = fixture.componentInstance;
     fixture.detectChanges();


### PR DESCRIPTION
There is nothing async in the beforeEach to wait for as it is written.

The other option would be to leave it in and then add in the closing parenthesis that is missing on line 12.