### PR TITLE
feat: use Ionic standalone components

### DIFF
--- a/packages/schematics/component/files/__name@dasherize@if-flat__/__name@dasherize__.__type@dasherize__.spec.ts.template
+++ b/packages/schematics/component/files/__name@dasherize@if-flat__/__name@dasherize__.__type@dasherize__.spec.ts.template
@@ -1,5 +1,5 @@
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { IonicModule } from '@ionic/angular';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';<% if(!standalone) {%>
+import { IonicModule } from '@ionic/angular';<%} %>
 
 import { <%= classify(name) %><%= classify(type) %> } from './<%= dasherize(name) %>.<%= dasherize(type) %>';
 
@@ -8,9 +8,10 @@ describe('<%= classify(name) %><%= classify(type) %>', () => {
   let fixture: ComponentFixture<<%= classify(name) %><%= classify(type) %>>;
 
   beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
+    TestBed.configureTestingModule({<% if(!standalone) {%>
       declarations: [ <%= classify(name) %><%= classify(type) %> ],
-      imports: [IonicModule.forRoot()]
+      imports: [IonicModule.forRoot()]<%} %><% if(standalone) {%>
+      imports: [<%= classify(name) %><%= classify(type) %>],<%} %>
     }).compileComponents();
 
     fixture = TestBed.createComponent(<%= classify(name) %><%= classify(type) %>);

--- a/packages/schematics/component/files/__name@dasherize@if-flat__/__name@dasherize__.__type@dasherize__.ts.template
+++ b/packages/schematics/component/files/__name@dasherize@if-flat__/__name@dasherize__.__type@dasherize__.ts.template
@@ -3,7 +3,8 @@ import { Component, OnInit } from '@angular/core';
 @Component({
   selector: '<%= selector %>',
   templateUrl: './<%= dasherize(name) %>.<%= dasherize(type) %>.html',
-  styleUrls: ['./<%= dasherize(name) %>.<%= dasherize(type) %>.<%= styleext %>'],
+  styleUrls: ['./<%= dasherize(name) %>.<%= dasherize(type) %>.<%= styleext %>'],<% if(standalone) {%>
+  standalone: true,<%} %>
 })
 export class <%= classify(name) %><%= classify(type) %>  implements OnInit {
 

--- a/packages/schematics/page/files/__name@dasherize@if-flat__/__name@dasherize__.page.ts
+++ b/packages/schematics/page/files/__name@dasherize@if-flat__/__name@dasherize__.page.ts
@@ -2,14 +2,14 @@ import { Component, OnInit } from '@angular/core';<% if(routePath) { %>
 import { ActivatedRoute, Params } from '@angular/router';<% } %><% if(standalone) {%>
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { IonicModule } from '@ionic/angular';<%} %>
+import { IonContent, IonHeader, IonTitle, IonToolbar } from '@ionic/angular/standalone';<%} %>
 
 @Component({
   selector: '<%= selector %>',
   templateUrl: './<%= dasherize(name) %>.page.html',
   styleUrls: ['./<%= dasherize(name) %>.page.<%= styleext %>'],<% if(standalone) {%>
   standalone: true,
-  imports: [IonicModule, CommonModule, FormsModule]<%} %>
+  imports: [IonContent, IonHeader, IonTitle, IonToolbar, CommonModule, FormsModule]<%} %>
 })
 export class <%= classify(name) %>Page implements OnInit {<% if(routePath) { %>
 


### PR DESCRIPTION
Support for generating standalone components and pages was added in https://github.com/ionic-team/angular-toolkit/commit/5523f7a8b891b86a0db0ab7781529211cd6a9d83. However, this work used the lazy loaded build of Ionic via `IonicModule` since Ionic standalone components did not exist yet.

Now that Ionic standalone components have been released, I'd like to update the page/component generation to use Ionic standalone components instead of `IonicModule`.

Note: You may encounter a `waitForAsync` syntax error when testing. This is fixed in https://github.com/ionic-team/angular-toolkit/pull/505.

closes #500