### PR TITLE
fix: standalone component can be created

### DIFF
--- a/packages/schematics/component/schema.d.ts
+++ b/packages/schematics/component/schema.d.ts
@@ -12,4 +12,5 @@ export interface Schema {
   export?: boolean;
   entryComponent?: boolean;
   type?: string;
+  standalone?: boolean;
 }

--- a/packages/schematics/component/schema.json
+++ b/packages/schematics/component/schema.json
@@ -85,6 +85,11 @@
       "type": "string",
       "description": "Adds a developer-defined type to the filename, in the format \"name.type.ts\".",
       "default": "Component"
+    },
+    "standalone": {
+      "type": "boolean",
+      "description": "Specifies if the component should be standalone",
+      "default": false
     }
   },
   "required": []


### PR DESCRIPTION
resolves #509

`standalone` was not added to the schema, so setting `--standalone` never did anything and the `standalone` variable in the template was never defined.