### PR TITLE
chore(cd): publish through the npm CLI so provenance works

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,7 +6,9 @@ on:
       - stable
 
 permissions:
-  contents: read
+  # `lerna version` pushes the release commit and tags and creates the GitHub release,
+  # so the token needs write access to contents. id-token is for npm provenance.
+  contents: write
   id-token: write
 
 jobs:
@@ -26,8 +28,11 @@ jobs:
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
-      - name: 🟢 Ensure Latest npm
-        run: npm install -g npm@latest
+      # npm 12 requires Node >=22.22.2, so `npm@latest` cannot run on the Node 20 pinned
+      # above. npm 11 is the newest line that does, and it supports both provenance and
+      # OIDC trusted publishing.
+      - name: 🟢 Ensure Supported npm
+        run: npm install -g npm@11
         shell: bash
       - name: 📦 Install Dependencies
         run: npm ci --no-package-lock
@@ -35,9 +40,14 @@ jobs:
       - name: 🔄 Bootstrap
         run: npm run bootstrap -- --ignore-scripts
         shell: bash
-      - name: 🚀 Release
-        run: npm run publish:ci -- --provenance
+      - name: 🔖 Version
+        run: npm run version:ci
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # `lerna publish` uploads via libnpmpublish@4, which supports neither provenance nor
+      # OIDC trusted publishing, so the upload goes through the npm CLI instead.
+      - name: 🚀 Publish
+        run: npm run publish:ci
+        shell: bash
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "format:check": "prettier \"**/*.ts\" --check",
     "prepublishOnly": "npm run build",
     "publish:testing": "lerna publish prerelease --preid=testing --exact --no-git-tag-version --no-push --dist-tag=testing",
-    "publish:ci": "lerna publish -m 'chore(release): publish [skip ci]' --exact --conventional-commits --yes --no-verify-access",
+    "version:ci": "lerna version -m 'chore(release): publish [skip ci]' --exact --conventional-commits --yes",
+    "publish:ci": "./scripts/publish-packages.sh",
     "publish:ci:testing": "lerna publish prerelease --preid=testing --no-git-tag-version --no-push --dist-tag=testing  -m 'chore(release): publish [skip ci]' --exact --conventional-commits --yes",
     "cz": "git-cz"
   },

--- a/scripts/publish-packages.sh
+++ b/scripts/publish-packages.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# Publishes each package whose current version is not on the registry yet.
+#
+# Versioning still runs through `lerna version`, but the upload has to go through the
+# npm CLI: lerna 4 publishes with libnpmpublish@4, which supports neither provenance
+# nor OIDC trusted publishing, so `lerna publish` cannot satisfy npm's requirements.
+#
+# Run this after `npm run version:ci`, from the repo root.
+
+set -euo pipefail
+
+published=0
+
+for manifest in packages/*/package.json; do
+  pkg_dir=$(dirname "$manifest")
+  name=$(node -p "require('./$manifest').name")
+  version=$(node -p "require('./$manifest').version")
+
+  if [ "$(node -p "require('./$manifest').private === true")" = "true" ]; then
+    echo "skip     $name (private)"
+    continue
+  fi
+
+  # Lerna versions packages independently, so a release may bump only one of them.
+  if npm view "$name@$version" version >/dev/null 2>&1; then
+    echo "skip     $name@$version (already on registry)"
+    continue
+  fi
+
+  echo "publish  $name@$version"
+  (cd "$pkg_dir" && npm publish --provenance --access public)
+  published=$((published + 1))
+done
+
+echo "published $published package(s)"


### PR DESCRIPTION
Fixes the release pipeline so it can publish `13.0.0`. Targets `stable` directly because CD reads the workflow from the pushed commit, so the fix has to be on the release branch to take effect.

## What is the current behavior?

Currently the release workflow cannot publish. [Run 32296237958](https://github.com/ionic-team/angular-toolkit/actions/runs/32296237958) failed on the `Ensure Latest npm` step, and there are three more failures queued up behind it. None of this had run before, because #526 moved the workflow off tokens after the last release, so `12.3.0` was published by the older token-based workflow.

1. `npm install -g npm@latest` resolves to npm 12.0.2, which requires `node ^22.22.2 || ^24.15.0 || >=26.0.0`. The workflow pins Node 20, so the install fails with `EBADENGINE`.
2. `lerna publish --provenance` cannot work. Lerna 4's CLI is yargs `.strict()` and `publish` does not declare a `provenance` option, so it exits with `Unknown argument: provenance`.
3. Lerna 4 uploads through `libnpmpublish@4.0.2`, which has no provenance support and no OIDC support. Since it never shells out to `npm publish`, upgrading the global npm does nothing for the upload, and trusted publishing is unreachable from `lerna publish` at this version.
4. `permissions: contents: read` cannot push the release commit or tags, or create the GitHub release. Before #526 there was no `permissions` block, so the default write access applied.

## What is the new behavior?

The release is split in two. Versioning stays with lerna, so bumps, changelogs, tags, and the GitHub release all work exactly as before. The upload moves to the npm CLI, which is what actually supports provenance and OIDC trusted publishing.

- `version:ci` runs `lerna version`, keeping the `lerna.json` config (`allowBranch`, `conventionalCommits`, `createRelease`, the `[skip ci]` message, `tagVersionPrefix`).
- `publish:ci` runs `scripts/publish-packages.sh`, which publishes each package with `npm publish --provenance`.
- npm is pinned to `npm@11`, the newest line that runs on Node 20 and still supports provenance and OIDC. This keeps CD on the same Node version as CI.
- `contents` is now `write`.

The publish script skips any package whose version is already on the registry, because these version independently and a release may bump only one of them.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

No package code changes. This commit touches only `.github/workflows/cd.yml`, the root `package.json`, and a new script, so lerna attributes it to neither package and it does not affect the computed versions.

## Other information

I verified locally that both packages still compute a major from the v9 squash on `stable` (`0883d9b`), which carries the `BREAKING CHANGE:` footer:

```
packages/schematics            commits=1  => MAJOR (12.3.0 -> 13.0.0)
packages/cordova-builders      commits=1  => MAJOR (12.3.0 -> 13.0.0)
```

`lerna changed` lists both packages, and `npm run version:ci` parses its flags and loads the `lerna.json` config cleanly, failing only on the missing `GH_TOKEN` that CI supplies. The publish script's skip logic was tested against both the already-published case and a simulated `13.0.0`.

Note: I could not verify the OIDC handshake itself without running a real publish, so that part is unproven. It also depends on trusted publishing being configured on npmjs.com for both `@ionic/angular-toolkit` and `@ionic/cordova-builders`. If either is missing, the publish step will fail on auth, and the fix is to add the trusted publisher for that package rather than to change the workflow again.

Merging this triggers CD, which will cut the release.
